### PR TITLE
workaround a CAN statement that failed to include a polygon

### DIFF
--- a/tests/nws/products/test_products_vtec.py
+++ b/tests/nws/products/test_products_vtec.py
@@ -60,9 +60,18 @@ def test_200302_issue203(dbcursor):
         prod.sql(dbcursor)
         if i == 0:
             assert prod.segments[0].sbw
-        if i == 1:
-            assert prod.warnings[0].find("should have contained") > -1
-            assert prod.segments[0].sbw is None
+            continue
+        assert prod.warnings[0].find("should have contained") > -1
+        assert prod.segments[0].sbw is None
+        assert len(prod.warnings) == 2
+        dbcursor.execute(
+            """
+            SELECT status from sbw_2020 WHERE wfo = 'CAE' and
+            eventid = 24 and phenomena = 'FL' and significance = 'W'
+            and status = 'CAN'
+        """
+        )
+        assert dbcursor.rowcount == 1
 
 
 def test_200224_urls():


### PR DESCRIPTION
If a VTEC product that `CAN`cels an event failed to properly include a polygon, the `sbw` table was left with a dangling and not canceled polygon. This change introduces the issuance polygon into the cancels statement, so to allow downstream logic to function.  Ultimately, this is GIGO.