### PR TITLE
replace pytz usage with zoneinfo

### DIFF
--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -1,3 +1,5 @@
+# workaround pytz shortcomings
+backports.zoneinfo;python_version<"3.9"
 sphinxcontrib-napoleon
 oauth2client
 urllib3

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     pandas
     pydantic
     pyproj
-    pytz
     psycopg2
     scipy
     shapely

--- a/src/pyiem/iemre.py
+++ b/src/pyiem/iemre.py
@@ -9,10 +9,10 @@
 import string
 import random
 import datetime
+from datetime import timezone
 
 from affine import Affine
 import numpy as np
-import pytz
 import xarray as xr
 from six import string_types
 from pyiem.util import get_dbconn
@@ -46,7 +46,7 @@ def get_table(valid):
     # careful here, a datetime is not an instance of date
     if isinstance(valid, datetime.datetime):
         table = "iemre_hourly_%s" % (
-            valid.astimezone(pytz.UTC).strftime("%Y%m"),
+            valid.astimezone(timezone.utc).strftime("%Y%m"),
         )
     else:
         table = f"iemre_daily_{valid.year}"
@@ -225,8 +225,8 @@ def hourly_offset(dtobj):
     Returns:
       int time index in the netcdf file
     """
-    if dtobj.tzinfo and dtobj.tzinfo != pytz.utc:
-        dtobj = dtobj.astimezone(pytz.utc)
+    if dtobj.tzinfo and dtobj.tzinfo != timezone.utc:
+        dtobj = dtobj.astimezone(timezone.utc)
     base = dtobj.replace(
         month=1, day=1, hour=0, minute=0, second=0, microsecond=0
     )

--- a/src/pyiem/iemre.py
+++ b/src/pyiem/iemre.py
@@ -8,8 +8,7 @@
 """
 import string
 import random
-import datetime
-from datetime import timezone
+from datetime import timezone, datetime
 
 from affine import Affine
 import numpy as np
@@ -44,7 +43,7 @@ def get_table(valid):
       str tablename
     """
     # careful here, a datetime is not an instance of date
-    if isinstance(valid, datetime.datetime):
+    if isinstance(valid, datetime):
         table = "iemre_hourly_%s" % (
             valid.astimezone(timezone.utc).strftime("%Y%m"),
         )
@@ -208,7 +207,7 @@ def get_hourly_ncname(year):
 def daily_offset(ts):
     """ Compute the timestamp index in the netcdf file """
     # In case ts is passed here as a datetime.date object
-    ts = datetime.datetime(ts.year, ts.month, ts.day)
+    ts = datetime(ts.year, ts.month, ts.day)
     base = ts.replace(
         month=1, day=1, hour=0, minute=0, second=0, microsecond=0
     )

--- a/src/pyiem/mrms.py
+++ b/src/pyiem/mrms.py
@@ -3,8 +3,7 @@
 Hopefully useful functions to help with the processing of MRMS data
 """
 import struct
-import datetime
-from datetime import timezone
+from datetime import timezone, datetime
 import gzip
 import os
 
@@ -57,7 +56,7 @@ def fetch(product, valid, tmpdir="/mesonet/tmp"):
             fd.write(req.content)
         return tmpfn
     # Option 3, we go look at MRMS website, if timestamp is recent
-    utcnow = datetime.datetime.utcnow()
+    utcnow = datetime.utcnow()
     if valid.tzinfo is not None:
         utcnow = utcnow.replace(tzinfo=timezone.utc)
     if (utcnow - valid).total_seconds() > 86400:
@@ -168,7 +167,7 @@ def reader(fn):
         metadata["ul_lon_cc"] - (scale_lon / float(grid_scale)) / 2.0
     )
 
-    metadata["valid"] = datetime.datetime(
+    metadata["valid"] = datetime(
         year, month, day, hour, minute, second
     ).replace(tzinfo=timezone.utc)
 

--- a/src/pyiem/mrms.py
+++ b/src/pyiem/mrms.py
@@ -4,10 +4,10 @@ Hopefully useful functions to help with the processing of MRMS data
 """
 import struct
 import datetime
+from datetime import timezone
 import gzip
 import os
 
-import pytz
 import requests
 import numpy as np
 
@@ -59,7 +59,7 @@ def fetch(product, valid, tmpdir="/mesonet/tmp"):
     # Option 3, we go look at MRMS website, if timestamp is recent
     utcnow = datetime.datetime.utcnow()
     if valid.tzinfo is not None:
-        utcnow = utcnow.replace(tzinfo=pytz.utc)
+        utcnow = utcnow.replace(tzinfo=timezone.utc)
     if (utcnow - valid).total_seconds() > 86400:
         # Can't do option 3!
         return None
@@ -170,7 +170,7 @@ def reader(fn):
 
     metadata["valid"] = datetime.datetime(
         year, month, day, hour, minute, second
-    ).replace(tzinfo=pytz.timezone("UTC"))
+    ).replace(tzinfo=timezone.utc)
 
     struct.unpack("%si" % (nz,), fp.read(nz * 4))  # levels
     struct.unpack("i", fp.read(4))  # z_scale

--- a/src/pyiem/ncei/ds3505.py
+++ b/src/pyiem/ncei/ds3505.py
@@ -2,12 +2,13 @@
 
     https://www1.ncdc.noaa.gov/pub/data/ish/ish-format-document.pdf
 """
+# pylint: disable=too-many-lines
 import re
 import warnings
 import datetime
+from datetime import timezone
 import json
 
-import pytz
 from metar.Metar import Metar
 from metar.Metar import ParserError as MetarParserError
 from metpy.units import units
@@ -1668,7 +1669,7 @@ def parser(msg, call_id, add_metar=False):
         return
     data["valid"] = datetime.datetime.strptime(
         "%s %s" % (data["yyyymmdd"], data["hhmi"]), "%Y%m%d %H%M"
-    ).replace(tzinfo=pytz.utc)
+    ).replace(tzinfo=timezone.utc)
     data["call_id"] = call_id
     data["lat"] = _d1000(data["lat"])
     data["lon"] = _d1000(data["lon"])

--- a/src/pyiem/ncei/ds3505.py
+++ b/src/pyiem/ncei/ds3505.py
@@ -5,8 +5,7 @@
 # pylint: disable=too-many-lines
 import re
 import warnings
-import datetime
-from datetime import timezone
+from datetime import timezone, datetime
 import json
 
 from metar.Metar import Metar
@@ -1667,7 +1666,7 @@ def parser(msg, call_id, add_metar=False):
     # Seems like these obs with this flag are 'bad'
     if data["srcflag"] in ["A", "B"]:
         return
-    data["valid"] = datetime.datetime.strptime(
+    data["valid"] = datetime.strptime(
         "%s %s" % (data["yyyymmdd"], data["hhmi"]), "%Y%m%d %H%M"
     ).replace(tzinfo=timezone.utc)
     data["call_id"] = call_id

--- a/src/pyiem/nwnformat.py
+++ b/src/pyiem/nwnformat.py
@@ -2,8 +2,7 @@
 
 Which is a format used by the Texas Weather Sensors KCCI-TV Operates
 """
-import datetime
-from datetime import timezone
+from datetime import timezone, datetime
 import traceback
 import re
 import math
@@ -153,12 +152,12 @@ class nwnformat:
 
     def setTS(self, newval):
         try:
-            self.ts = datetime.datetime.strptime(newval, "%m/%d/%y %H:%M:%S")
+            self.ts = datetime.strptime(newval, "%m/%d/%y %H:%M:%S")
         except Exception:
             traceback.print_exc()
             self.error = 100
             return
-        now = datetime.datetime.now()
+        now = datetime.now()
         if (now - self.ts).total_seconds() > 7200:
             self.error = 101
 
@@ -190,7 +189,7 @@ class nwnformat:
 
     def parseLineRT(self, tokens):
         if self.ts is None:
-            _t = datetime.datetime.utcnow()
+            _t = datetime.utcnow()
             _t = _t.replace(second=0, microsecond=0, tzinfo=timezone.utc)
             self.ts = _t.astimezone(ZoneInfo("America/Chicago"))
 
@@ -202,7 +201,7 @@ class nwnformat:
         elif lineType == "Min":
             self.parseMinLineRT(tokens)
         else:
-            _t = datetime.datetime.utcnow()
+            _t = datetime.utcnow()
             _t = _t.replace(second=0, microsecond=0, tzinfo=timezone.utc)
             self.ts = _t.astimezone(ZoneInfo("America/Chicago"))
             self.parseCurrentLineRT(tokens)

--- a/src/pyiem/nwnformat.py
+++ b/src/pyiem/nwnformat.py
@@ -3,11 +3,16 @@
 Which is a format used by the Texas Weather Sensors KCCI-TV Operates
 """
 import datetime
+from datetime import timezone
 import traceback
 import re
 import math
 
-import pytz
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
+
 import pyiem.reference as reference
 import pyiem.util as util
 
@@ -186,10 +191,8 @@ class nwnformat:
     def parseLineRT(self, tokens):
         if self.ts is None:
             _t = datetime.datetime.utcnow()
-            _t = _t.replace(
-                second=0, microsecond=0, tzinfo=pytz.timezone("UTC")
-            )
-            self.ts = _t.astimezone(pytz.timezone("America/Chicago"))
+            _t = _t.replace(second=0, microsecond=0, tzinfo=timezone.utc)
+            self.ts = _t.astimezone(ZoneInfo("America/Chicago"))
 
         if len(tokens) != 14:
             return
@@ -200,10 +203,8 @@ class nwnformat:
             self.parseMinLineRT(tokens)
         else:
             _t = datetime.datetime.utcnow()
-            _t = _t.replace(
-                second=0, microsecond=0, tzinfo=pytz.timezone("UTC")
-            )
-            self.ts = _t.astimezone(pytz.timezone("America/Chicago"))
+            _t = _t.replace(second=0, microsecond=0, tzinfo=timezone.utc)
+            self.ts = _t.astimezone(ZoneInfo("America/Chicago"))
             self.parseCurrentLineRT(tokens)
 
     def parseMaxLineRT(self, tokens):

--- a/src/pyiem/nws/gini.py
+++ b/src/pyiem/nws/gini.py
@@ -4,8 +4,7 @@ Processing of GINI formatted data found on NOAAPORT
 import struct
 import math
 import zlib
-import datetime
-from datetime import timezone
+from datetime import timezone, datetime
 import os
 
 import pyproj
@@ -424,7 +423,7 @@ class GINIZFile:
         mi = struct.unpack("> B", hdata[12:13])[0]
         ss = struct.unpack("> B", hdata[13:14])[0]
         # hs = struct.unpack("> B", hdata[14:15] )[0]
-        meta["valid"] = datetime.datetime(yr, mo, dy, hh, mi, ss).replace(
+        meta["valid"] = datetime(yr, mo, dy, hh, mi, ss).replace(
             tzinfo=timezone.utc
         )
         meta["map_projection"] = struct.unpack("> B", hdata[15:16])[0]

--- a/src/pyiem/nws/gini.py
+++ b/src/pyiem/nws/gini.py
@@ -5,9 +5,9 @@ import struct
 import math
 import zlib
 import datetime
+from datetime import timezone
 import os
 
-import pytz
 import pyproj
 import numpy as np
 from pyiem.util import logger
@@ -425,7 +425,7 @@ class GINIZFile:
         ss = struct.unpack("> B", hdata[13:14])[0]
         # hs = struct.unpack("> B", hdata[14:15] )[0]
         meta["valid"] = datetime.datetime(yr, mo, dy, hh, mi, ss).replace(
-            tzinfo=pytz.timezone("UTC")
+            tzinfo=timezone.utc
         )
         meta["map_projection"] = struct.unpack("> B", hdata[15:16])[0]
         meta["proj_center_flag"] = struct.unpack("> B", hdata[36:37])[0] >> 7

--- a/src/pyiem/nws/hvtec.py
+++ b/src/pyiem/nws/hvtec.py
@@ -1,7 +1,6 @@
 """Process HVTEC encoding."""
 import re
-import datetime
-from datetime import timezone
+from datetime import timezone, datetime
 
 from pyiem.nws.nwsli import NWSLI
 
@@ -60,7 +59,7 @@ def contime(s):
     if len(re.findall("0000*T", s)) > 0:
         return None
     try:
-        ts = datetime.datetime.strptime(s, "%y%m%dT%H%MZ")
+        ts = datetime.strptime(s, "%y%m%dT%H%MZ")
         return ts.replace(tzinfo=timezone.utc)
     except Exception as err:
         print(err)

--- a/src/pyiem/nws/hvtec.py
+++ b/src/pyiem/nws/hvtec.py
@@ -1,8 +1,8 @@
 """Process HVTEC encoding."""
 import re
 import datetime
+from datetime import timezone
 
-import pytz
 from pyiem.nws.nwsli import NWSLI
 
 #         nwsli        sev         cause
@@ -61,7 +61,7 @@ def contime(s):
         return None
     try:
         ts = datetime.datetime.strptime(s, "%y%m%dT%H%MZ")
-        return ts.replace(tzinfo=pytz.UTC)
+        return ts.replace(tzinfo=timezone.utc)
     except Exception as err:
         print(err)
         return None

--- a/src/pyiem/nws/lsr.py
+++ b/src/pyiem/nws/lsr.py
@@ -1,8 +1,7 @@
 """The Atomic Local Storm Report ... Report"""
 # pylint: disable=unsubscriptable-object
 import re
-import datetime
-from datetime import timezone
+from datetime import timezone, timedelta
 
 from pyiem import reference
 
@@ -138,14 +137,12 @@ class LSR:
         if self.valid is None:
             return
         # We can't just assign the timezone (maybe we can someday)
-        self.utcvalid = self.valid + datetime.timedelta(
-            hours=reference.offsets[z]
-        )
+        self.utcvalid = self.valid + timedelta(hours=reference.offsets[z])
         self.utcvalid = self.utcvalid.replace(tzinfo=timezone.utc)
         self.valid = self.utcvalid.astimezone(tz)
         # complexity with non-DST sites
         if z.endswith("ST") and self.valid.dst():
-            self.valid -= datetime.timedelta(hours=1)
+            self.valid -= timedelta(hours=1)
         self.z = z
 
     def mag_string(self):

--- a/src/pyiem/nws/lsr.py
+++ b/src/pyiem/nws/lsr.py
@@ -2,7 +2,7 @@
 # pylint: disable=unsubscriptable-object
 import re
 import datetime
-import pytz
+from datetime import timezone
 
 from pyiem import reference
 
@@ -137,11 +137,11 @@ class LSR:
         """ retroactive assignment of timezone, so to improve attrs """
         if self.valid is None:
             return
-        # We can't just assign the timezone as this does not work in pytz
+        # We can't just assign the timezone (maybe we can someday)
         self.utcvalid = self.valid + datetime.timedelta(
             hours=reference.offsets[z]
         )
-        self.utcvalid = self.utcvalid.replace(tzinfo=pytz.UTC)
+        self.utcvalid = self.utcvalid.replace(tzinfo=timezone.utc)
         self.valid = self.utcvalid.astimezone(tz)
         # complexity with non-DST sites
         if z.endswith("ST") and self.valid.dst():

--- a/src/pyiem/nws/product.py
+++ b/src/pyiem/nws/product.py
@@ -1,6 +1,5 @@
 """Base Class encapsulating a NWS Text Product"""
-import datetime
-from datetime import timezone
+from datetime import timezone, timedelta, datetime
 from collections import OrderedDict
 import re
 
@@ -157,8 +156,8 @@ def date_tokens2datetime(tokens):
         tokens[6],
     )
     # Careful here, need to go to UTC time first then come back!
-    now = datetime.datetime.strptime(dstr, "%I:%M %p %b %d %Y")
-    now += datetime.timedelta(hours=reference.offsets[z])
+    now = datetime.strptime(dstr, "%I:%M %p %b %d %Y")
+    now += timedelta(hours=reference.offsets[z])
     return z, tz, now.replace(tzinfo=timezone.utc)
 
 
@@ -395,7 +394,7 @@ class TextProductSegment:
         mi = int(gdict["ztime"][2:])
         self.tml_valid = self.ugcexpire.replace(hour=hh, minute=mi)
         if hh > self.ugcexpire.hour:
-            self.tml_valid = self.tml_valid - datetime.timedelta(days=1)
+            self.tml_valid = self.tml_valid - timedelta(days=1)
 
         self.tml_valid = self.tml_valid.replace(tzinfo=timezone.utc)
 
@@ -487,9 +486,7 @@ class TextProduct:
         self.tz = None
         self.geometry = None
         if utcnow is None:
-            self.utcnow = datetime.datetime.utcnow().replace(
-                tzinfo=timezone.utc
-            )
+            self.utcnow = datetime.utcnow().replace(tzinfo=timezone.utc)
         # make sure this is actualing in UTC
         self.utcnow = self.utcnow.astimezone(timezone.utc)
 
@@ -538,7 +535,7 @@ class TextProduct:
             localts = self.valid.astimezone(self.tz)
             # A bit of complexity as offices may not implement daylight saving
             if self.z.endswith("ST") and localts.dst():
-                localts -= datetime.timedelta(hours=1)
+                localts -= timedelta(hours=1)
             fmt = "%b %-d, %-I:%M %p " + self.z
         return localts.strftime(fmt)
 
@@ -652,10 +649,10 @@ class TextProduct:
             if wmo_day - self.utcnow.day == 1:  # Tomorrow
                 self.wmo_valid = self.wmo_valid.replace(day=wmo_day)
             elif wmo_day > 25 and self.utcnow.day < 15:  # Previous month!
-                self.wmo_valid = self.wmo_valid + datetime.timedelta(days=-10)
+                self.wmo_valid = self.wmo_valid + timedelta(days=-10)
                 self.wmo_valid = self.wmo_valid.replace(day=wmo_day)
             elif wmo_day < 5 and self.utcnow.day >= 15:  # next month
-                self.wmo_valid = self.wmo_valid + datetime.timedelta(days=10)
+                self.wmo_valid = self.wmo_valid + timedelta(days=10)
                 self.wmo_valid = self.wmo_valid.replace(day=wmo_day)
             else:
                 self.wmo_valid = self.wmo_valid.replace(day=wmo_day)

--- a/src/pyiem/nws/products/dsm.py
+++ b/src/pyiem/nws/products/dsm.py
@@ -1,6 +1,6 @@
 """Parser of the Daily Summary Message (DSM)."""
 import re
-import datetime
+from datetime import datetime, timedelta
 
 from metpy.units import units
 from pyiem.nws.product import TextProduct
@@ -51,7 +51,7 @@ def compute_time(date, timestamp):
     """Make a valid timestamp."""
     if timestamp is None:
         return None
-    return datetime.datetime(
+    return datetime(
         date.year,
         date.month,
         date.day,
@@ -75,9 +75,7 @@ class DSMProduct:
 
     def tzlocalize(self, tzinfo):
         """Localize the timestamps, tricky."""
-        offset = tzinfo.utcoffset(
-            datetime.datetime(2000, 1, 1)
-        ).total_seconds()
+        offset = tzinfo.utcoffset(datetime(2000, 1, 1)).total_seconds()
         for name in [
             "high_time",
             "low_time",
@@ -88,7 +86,7 @@ class DSMProduct:
             if val is None:
                 continue
             # Need to convert timestamp into standard time time, tricky
-            ts = val - datetime.timedelta(seconds=offset)
+            ts = val - timedelta(seconds=offset)
             setattr(
                 self,
                 name,
@@ -107,7 +105,7 @@ class DSMProduct:
         # Is this ob from 'last year'
         if ts.month == 12 and utcnow.month == 1:
             ts = ts.replace(year=(ts.year - 1))
-        self.date = datetime.date(ts.year, ts.month, ts.day)
+        self.date = datetime(ts.year, ts.month, ts.day).date()
         self.high_time = compute_time(
             self.date, self.groupdict.get("hightime")
         )

--- a/src/pyiem/nws/products/dsm.py
+++ b/src/pyiem/nws/products/dsm.py
@@ -76,7 +76,7 @@ class DSMProduct:
     def tzlocalize(self, tzinfo):
         """Localize the timestamps, tricky."""
         offset = tzinfo.utcoffset(
-            datetime.datetime(2000, 1, 1), is_dst=False
+            datetime.datetime(2000, 1, 1)
         ).total_seconds()
         for name in [
             "high_time",

--- a/src/pyiem/nws/products/ffg.py
+++ b/src/pyiem/nws/products/ffg.py
@@ -5,9 +5,9 @@ https://www.weather.gov/media/notification/pdfs/pns18-13disc_county_ffg.pdf
 """
 import re
 import datetime
+from datetime import timezone
 
 import pandas as pd
-import pytz
 from pyiem.nws.product import TextProduct
 
 SHEFRE = re.compile(
@@ -58,11 +58,11 @@ class FFGProduct(TextProduct):
         group = shef.groupdict()
         self.issue = datetime.datetime.strptime(
             group["date"][-6:], "%y%m%d"
-        ).replace(tzinfo=pytz.UTC)
+        ).replace(tzinfo=timezone.utc)
         self.issue = self.issue.replace(hour=(int(group["hh"]) % 24))
         dc = datetime.datetime.strptime(
             group["valid"][-10:], "%y%m%d%H%M"
-        ).replace(tzinfo=pytz.utc)
+        ).replace(tzinfo=timezone.utc)
         # Emailed KTUA about this on 17 Apr 2017
         if (
             abs((self.issue - dc).total_seconds()) > (12 * 3600.0)

--- a/src/pyiem/nws/products/ffg.py
+++ b/src/pyiem/nws/products/ffg.py
@@ -4,8 +4,7 @@ NWS Discontinued 30 Sep 2018
 https://www.weather.gov/media/notification/pdfs/pns18-13disc_county_ffg.pdf
 """
 import re
-import datetime
-from datetime import timezone
+from datetime import timezone, datetime
 
 import pandas as pd
 from pyiem.nws.product import TextProduct
@@ -56,13 +55,13 @@ class FFGProduct(TextProduct):
             self.warnings.append("Failed to find SHEF variable!")
             return
         group = shef.groupdict()
-        self.issue = datetime.datetime.strptime(
-            group["date"][-6:], "%y%m%d"
-        ).replace(tzinfo=timezone.utc)
+        self.issue = datetime.strptime(group["date"][-6:], "%y%m%d").replace(
+            tzinfo=timezone.utc
+        )
         self.issue = self.issue.replace(hour=(int(group["hh"]) % 24))
-        dc = datetime.datetime.strptime(
-            group["valid"][-10:], "%y%m%d%H%M"
-        ).replace(tzinfo=timezone.utc)
+        dc = datetime.strptime(group["valid"][-10:], "%y%m%d%H%M").replace(
+            tzinfo=timezone.utc
+        )
         # Emailed KTUA about this on 17 Apr 2017
         if (
             abs((self.issue - dc).total_seconds()) > (12 * 3600.0)

--- a/src/pyiem/nws/products/hml.py
+++ b/src/pyiem/nws/products/hml.py
@@ -5,9 +5,9 @@ Attempt to break up the HML product into atomic data
 """
 import re
 import datetime
+from datetime import timezone
 import xml.etree.cElementTree as ET
 
-import pytz
 import pandas as pd
 import pyiem.nws.product as product
 
@@ -26,7 +26,7 @@ def parseUTC(s):
     if s is None:
         return None
     return datetime.datetime.strptime(s[:19], "%Y-%m-%dT%H:%M:%S").replace(
-        tzinfo=pytz.UTC
+        tzinfo=timezone.utc
     )
 
 

--- a/src/pyiem/nws/products/hml.py
+++ b/src/pyiem/nws/products/hml.py
@@ -4,8 +4,7 @@ Attempt to break up the HML product into atomic data
 
 """
 import re
-import datetime
-from datetime import timezone
+from datetime import timezone, datetime
 import xml.etree.cElementTree as ET
 
 import pandas as pd
@@ -25,7 +24,7 @@ def parseUTC(s):
     """Parse an ISO-ish string into UTC timestamp"""
     if s is None:
         return None
-    return datetime.datetime.strptime(s[:19], "%Y-%m-%dT%H:%M:%S").replace(
+    return datetime.strptime(s[:19], "%Y-%m-%dT%H:%M:%S").replace(
         tzinfo=timezone.utc
     )
 

--- a/src/pyiem/nws/products/mcd.py
+++ b/src/pyiem/nws/products/mcd.py
@@ -4,8 +4,8 @@
 """
 import re
 import datetime
+from datetime import timezone
 
-import pytz
 from shapely.geometry import Polygon as ShapelyPolygon
 from pyiem.nws.product import TextProduct
 from pyiem.exceptions import MCDException
@@ -67,7 +67,10 @@ class MCDProduct(TextProduct):
             expire = self.valid + datetime.timedelta(days=25)
             expire = expire.replace(day=day2, hour=hour2, minute=min2)
 
-        return issue.replace(tzinfo=pytz.UTC), expire.replace(tzinfo=pytz.UTC)
+        return (
+            issue.replace(tzinfo=timezone.utc),
+            expire.replace(tzinfo=timezone.utc),
+        )
 
     def find_watch_probability(self):
         """ Find the probability of watch issuance for SPC MCD"""

--- a/src/pyiem/nws/products/mcd.py
+++ b/src/pyiem/nws/products/mcd.py
@@ -3,8 +3,7 @@
  parsing of Weather Prediction Center's MPD
 """
 import re
-import datetime
-from datetime import timezone
+from datetime import timezone, datetime
 
 from shapely.geometry import Polygon as ShapelyPolygon
 from pyiem.nws.product import TextProduct
@@ -61,10 +60,10 @@ class MCDProduct(TextProduct):
         issue = self.valid.replace(day=day1, hour=hour1, minute=min1)
         expire = self.valid.replace(day=day2, hour=hour2, minute=min2)
         if day1 < self.valid.day and day1 == 1:
-            issue = self.valid + datetime.timedelta(days=25)
+            issue = self.valid + timedelta(days=25)
             issue = issue.replace(day=day1, hour=hour1, minute=min1)
         if day2 < self.valid.day and day2 == 1:
-            expire = self.valid + datetime.timedelta(days=25)
+            expire = self.valid + timedelta(days=25)
             expire = expire.replace(day=day2, hour=hour2, minute=min2)
 
         return (

--- a/src/pyiem/nws/products/metarcollect.py
+++ b/src/pyiem/nws/products/metarcollect.py
@@ -1,7 +1,6 @@
 """Encapsulates a text product holding METARs."""
 import re
-import datetime
-from datetime import timezone
+from datetime import timezone, timedelta
 
 try:
     from zoneinfo import ZoneInfo
@@ -120,7 +119,7 @@ def to_metar(textprod, text):
                     print("unparsed groups regex fail: %s" % (inst,))
             if str(inst).find("day is out of range for month") > -1:
                 if valid.day < 10:
-                    valid = valid.replace(day=1) - datetime.timedelta(days=1)
+                    valid = valid.replace(day=1) - timedelta(days=1)
         attempt += 1
 
     if mtr is not None:
@@ -132,13 +131,11 @@ def to_metar(textprod, text):
             print("Aborting due to time being None |%s|" % (text,))
             return None
         # don't allow data more than an hour into the future
-        ceiling = (textprod.utcnow + datetime.timedelta(hours=1)).replace(
-            tzinfo=None
-        )
+        ceiling = (textprod.utcnow + timedelta(hours=1)).replace(tzinfo=None)
         if mtr.time > ceiling:
             # careful, we may have obs from the previous month
             if ceiling.day < 5 and mtr.time.day > 15:
-                prevmonth = ceiling - datetime.timedelta(days=10)
+                prevmonth = ceiling - timedelta(days=10)
                 mtr.time = mtr.time.replace(
                     year=prevmonth.year, month=prevmonth.month
                 )
@@ -196,7 +193,7 @@ def _is_same_day(valid, tzname, hours=6):
         return False
     lts = valid.astimezone(tzinfo)
     # TODO we should likely somehow compute this in standard time, shrug
-    return lts.day == (lts - datetime.timedelta(hours=hours)).day
+    return lts.day == (lts - timedelta(hours=hours)).day
 
 
 class METARReport(Metar):

--- a/src/pyiem/nws/products/nldn.py
+++ b/src/pyiem/nws/products/nldn.py
@@ -2,10 +2,10 @@
 http://www.unidata.ucar.edu/data/lightning/nldn.html
 """
 import datetime
+from datetime import timezone
 import struct
 
 import pandas as pd
-import pytz
 
 
 class NLDNProduct:
@@ -56,7 +56,7 @@ def parser(buf):
         (tsec, nsec, lat1000, lon1000) = struct.unpack(">4i", chunk[:16])
         secs = float(tsec) + (nsec / 1000000.0)
         ts = datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=secs)
-        ts = ts.replace(tzinfo=pytz.utc)
+        ts = ts.replace(tzinfo=timezone.utc)
         (_, sgnl10, _) = struct.unpack(">3h", chunk[16:22])
         (multi, _, axis, eccentricity, ellipse, chisqr) = struct.unpack(
             "6b", chunk[22:28]

--- a/src/pyiem/nws/products/nldn.py
+++ b/src/pyiem/nws/products/nldn.py
@@ -1,8 +1,7 @@
 """
 http://www.unidata.ucar.edu/data/lightning/nldn.html
 """
-import datetime
-from datetime import timezone
+from datetime import timezone, datetime, timedelta
 import struct
 
 import pandas as pd
@@ -55,7 +54,7 @@ def parser(buf):
             break
         (tsec, nsec, lat1000, lon1000) = struct.unpack(">4i", chunk[:16])
         secs = float(tsec) + (nsec / 1000000.0)
-        ts = datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=secs)
+        ts = datetime(1970, 1, 1) + timedelta(seconds=secs)
         ts = ts.replace(tzinfo=timezone.utc)
         (_, sgnl10, _) = struct.unpack(">3h", chunk[16:22])
         (multi, _, axis, eccentricity, ellipse, chisqr) = struct.unpack(

--- a/src/pyiem/nws/products/vtec.py
+++ b/src/pyiem/nws/products/vtec.py
@@ -1,6 +1,6 @@
 """A NWS TextProduct that contains VTEC information."""
 # Standard Library Imports
-import datetime
+from datetime import timedelta
 
 from pyiem.nws.product import TextProduct, TextProductException
 from pyiem.nws.ugc import ugcs_to_text
@@ -131,7 +131,7 @@ class VTECProduct(TextProduct):
                     vtec.etn,
                     vtec.significance,
                     vtec.phenomena,
-                    self.valid - datetime.timedelta(days=offset),
+                    self.valid - timedelta(days=offset),
                     self.valid,
                     self.valid,
                 ),
@@ -570,9 +570,7 @@ class VTECProduct(TextProduct):
                     jmsg_dict["url"] += "_%s" % (
                         vtec.begints.strftime("%Y-%m-%dT%H:%MZ"),
                     )
-                    if vtec.begints > (
-                        self.utcnow + datetime.timedelta(hours=1)
-                    ):
+                    if vtec.begints > (self.utcnow + timedelta(hours=1)):
                         jmsg_dict["sts"] = " %s " % (
                             vtec.get_begin_string(self),
                         )
@@ -711,7 +709,7 @@ class VTECProduct(TextProduct):
             if vtec.phenomena in ["TO"] and vtec.significance == "W":
                 jdict["svs_special"] = segment.svs_search()
             if vtec.begints is not None and vtec.begints > (
-                self.utcnow + datetime.timedelta(hours=1)
+                self.utcnow + timedelta(hours=1)
             ):
                 jdict["sts"] = " %s " % (vtec.get_begin_string(self),)
 

--- a/src/pyiem/nws/vtec.py
+++ b/src/pyiem/nws/vtec.py
@@ -1,8 +1,8 @@
 """Support NWS VTEC encoding"""
 import re
 import datetime
+from datetime import timezone
 
-import pytz
 
 VTEC_RE = (
     r"(/([A-Z])\.([A-Z]+)\.([A-Z]+)\.([A-Z]+)\.([A-Z])\."
@@ -218,7 +218,7 @@ def contime(text):
         return None
     try:
         ts = datetime.datetime.strptime(text, "%y%m%dT%H%MZ")
-        return ts.replace(tzinfo=pytz.utc)
+        return ts.replace(tzinfo=timezone.utc)
     except Exception as err:
         print(err)
         return None

--- a/src/pyiem/nws/vtec.py
+++ b/src/pyiem/nws/vtec.py
@@ -1,7 +1,6 @@
 """Support NWS VTEC encoding"""
 import re
-import datetime
-from datetime import timezone
+from datetime import timezone, timedelta, datetime
 
 
 VTEC_RE = (
@@ -217,7 +216,7 @@ def contime(text):
     if re.findall("0000*T", text):
         return None
     try:
-        ts = datetime.datetime.strptime(text, "%y%m%dT%H%MZ")
+        ts = datetime.strptime(text, "%y%m%dT%H%MZ")
         return ts.replace(tzinfo=timezone.utc)
     except Exception as err:
         print(err)
@@ -269,7 +268,7 @@ class VTEC:
         if self.endts is None:
             return "until further notice"
         fmt = "%b %-d, %-I:%M %p"
-        if self.endts < (prod.valid + datetime.timedelta(hours=1)):
+        if self.endts < (prod.valid + timedelta(hours=1)):
             fmt = "%-I:%M %p"
         if prod.tz is None:
             fmt = "%b %-d, %-H:%M"
@@ -278,7 +277,7 @@ class VTEC:
             localts = self.endts.astimezone(prod.tz)
         # A bit of complexity as offices may not implement daylight saving
         if prod.z is not None and prod.z.endswith("ST") and localts.dst():
-            localts -= datetime.timedelta(hours=1)
+            localts -= timedelta(hours=1)
         return "till %s %s" % (
             localts.strftime(fmt),
             prod.z if prod.z is not None else "UTC",
@@ -289,12 +288,12 @@ class VTEC:
         if self.begints is None:
             return ""
         fmt = "%b %-d, %-I:%M %p"
-        if self.begints < (prod.valid + datetime.timedelta(hours=1)):
+        if self.begints < (prod.valid + timedelta(hours=1)):
             fmt = "%-I:%M %p"
         localts = self.begints.astimezone(prod.tz)
         # A bit of complexity as offices may not implement daylight saving
         if prod.z.endswith("ST") and localts.dst():
-            localts -= datetime.timedelta(hours=1)
+            localts -= timedelta(hours=1)
         return "valid at %s %s" % (localts.strftime(fmt), prod.z)
 
     def url(self, year):

--- a/src/pyiem/observation.py
+++ b/src/pyiem/observation.py
@@ -3,12 +3,17 @@
 from collections import UserDict
 import warnings
 import datetime
+from datetime import timezone
 import math
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 import numpy as np
 import metpy.calc as mcalc
 from metpy.units import units as munits
-import pytz
 
 # A nonsense default that is not None/SQL-null
 SENTINEL = 99999
@@ -156,7 +161,7 @@ class Observation:
         """
         if valid.tzinfo is None:
             warnings.warn("tzinfo is not set on valid, defaulting to UTC")
-            valid = valid.replace(tzinfo=pytz.UTC)
+            valid = valid.replace(tzinfo=timezone.utc)
         self.data = ObDict(
             {"station": station, "network": network, "valid": valid}
         )
@@ -336,7 +341,7 @@ class Observation:
         if rowcount != 1:
             # Create a new entry
             localvalid = self.data["valid"].astimezone(
-                pytz.timezone(self.data["tzname"])
+                ZoneInfo(self.data["tzname"])
             )
             # we don't want dates into the future as this will foul up others
             if localvalid.date() > datetime.date.today():

--- a/src/pyiem/observation.py
+++ b/src/pyiem/observation.py
@@ -2,8 +2,7 @@
 # pylint: disable=no-member
 from collections import UserDict
 import warnings
-import datetime
-from datetime import timezone
+from datetime import timezone, datetime
 import math
 
 try:
@@ -344,7 +343,7 @@ class Observation:
                 ZoneInfo(self.data["tzname"])
             )
             # we don't want dates into the future as this will foul up others
-            if localvalid.date() > datetime.date.today():
+            if localvalid.date() > datetime.now().date():
                 return False
             txn.execute(
                 f"INSERT into summary_{localvalid.year} "

--- a/src/pyiem/tracker.py
+++ b/src/pyiem/tracker.py
@@ -3,7 +3,11 @@ import datetime
 import smtplib
 from email.mime.text import MIMEText
 
-import pytz
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
+
 from pyiem.util import get_dbconn
 
 
@@ -93,7 +97,7 @@ class TrackerEngine:
         )
         trackerid = self.pcursor.fetchone()[0]
         # Create a tt_log entry
-        lts = ob["valid"].astimezone(pytz.timezone(nt.sts[sid]["tzname"]))
+        lts = ob["valid"].astimezone(ZoneInfo(nt.sts[sid]["tzname"]))
         msg = "Site Offline since %s" % (lts.strftime("%d %b %Y %H:%M %Z"),)
         self.pcursor.execute(
             "INSERT into tt_log (portfolio, s_mid, author, status_c, "
@@ -174,7 +178,7 @@ class TrackerEngine:
             "DELETE from offline where station = %s and network = %s",
             (sid, nt.sts[sid]["network"]),
         )
-        ltz = pytz.timezone(nt.sts[sid]["tzname"])
+        ltz = ZoneInfo(nt.sts[sid]["tzname"])
         lts = ob["valid"].astimezone(ltz)
         delta = ob["valid"] - offline[sid]["valid"]
         days = delta.days

--- a/src/pyiem/util.py
+++ b/src/pyiem/util.py
@@ -10,6 +10,7 @@ import time
 import random
 import logging
 import datetime
+from datetime import timezone
 import re
 import warnings
 import getpass
@@ -164,20 +165,18 @@ def ncopen(ncfn, mode="r", timeout=60):
 
 
 def utc(year=None, month=1, day=1, hour=0, minute=0, second=0, microsecond=0):
-    """Create a datetime instance with tzinfo=pytz.UTC
+    """Create a datetime instance with tzinfo=timezone.utc
 
     When no arguments are provided, returns `datetime.utcnow()`.
 
     Returns:
       datetime with tzinfo set
     """
-    import pytz
-
     if year is None:
-        return datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
+        return datetime.datetime.utcnow().replace(tzinfo=timezone.utc)
     return datetime.datetime(
         year, month, day, hour, minute, second, microsecond
-    ).replace(tzinfo=pytz.UTC)
+    ).replace(tzinfo=timezone.utc)
 
 
 def get_dbconn(database="mesosite", user=None, host=None, port=5432, **kwargs):

--- a/src/pyiem/util.py
+++ b/src/pyiem/util.py
@@ -9,8 +9,7 @@ import sys
 import time
 import random
 import logging
-import datetime
-from datetime import timezone
+from datetime import timezone, datetime
 import re
 import warnings
 import getpass
@@ -151,9 +150,9 @@ def ncopen(ncfn, mode="r", timeout=60):
 
     if mode != "w" and not os.path.isfile(ncfn):
         raise IOError("No such file %s" % (ncfn,))
-    sts = datetime.datetime.utcnow()
+    sts = datetime.utcnow()
     nc = None
-    while (datetime.datetime.utcnow() - sts).total_seconds() < timeout:
+    while (datetime.utcnow() - sts).total_seconds() < timeout:
         try:
             nc = netCDF4.Dataset(ncfn, mode)
             nc.set_auto_scale(True)
@@ -173,8 +172,8 @@ def utc(year=None, month=1, day=1, hour=0, minute=0, second=0, microsecond=0):
       datetime with tzinfo set
     """
     if year is None:
-        return datetime.datetime.utcnow().replace(tzinfo=timezone.utc)
-    return datetime.datetime(
+        return datetime.utcnow().replace(tzinfo=timezone.utc)
+    return datetime(
         year, month, day, hour, minute, second, microsecond
     ).replace(tzinfo=timezone.utc)
 
@@ -368,27 +367,25 @@ def get_autoplot_context(fdict, cfg):
         elif typ == "datetime":
             # tricky here, php has YYYY/mm/dd and CGI has YYYY-mm-dd
             if default is not None:
-                default = datetime.datetime.strptime(default, "%Y/%m/%d %H%M")
+                default = datetime.strptime(default, "%Y/%m/%d %H%M")
             if minval is not None:
-                minval = datetime.datetime.strptime(minval, "%Y/%m/%d %H%M")
+                minval = datetime.strptime(minval, "%Y/%m/%d %H%M")
             if maxval is not None:
-                maxval = datetime.datetime.strptime(maxval, "%Y/%m/%d %H%M")
+                maxval = datetime.strptime(maxval, "%Y/%m/%d %H%M")
             if value is not None:
                 if value.find(" ") == -1:
                     value += " 0000"
-                value = datetime.datetime.strptime(value, "%Y-%m-%d %H%M")
+                value = datetime.strptime(value, "%Y-%m-%d %H%M")
         elif typ == "date":
             # tricky here, php has YYYY/mm/dd and CGI has YYYY-mm-dd
             if default is not None:
-                default = datetime.datetime.strptime(
-                    default, "%Y/%m/%d"
-                ).date()
+                default = datetime.strptime(default, "%Y/%m/%d").date()
             if minval is not None:
-                minval = datetime.datetime.strptime(minval, "%Y/%m/%d").date()
+                minval = datetime.strptime(minval, "%Y/%m/%d").date()
             if maxval is not None:
-                maxval = datetime.datetime.strptime(maxval, "%Y/%m/%d").date()
+                maxval = datetime.strptime(maxval, "%Y/%m/%d").date()
             if value is not None:
-                value = datetime.datetime.strptime(value, "%Y-%m-%d").date()
+                value = datetime.strptime(value, "%Y-%m-%d").date()
         elif typ == "vtec_ps":
             # VTEC phenomena and significance
             defaults = {}

--- a/src/pyiem/windrose_utils.py
+++ b/src/pyiem/windrose_utils.py
@@ -1,9 +1,13 @@
 """util script to call `windrose` package"""
 import datetime
 
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
+
 import numpy as np
 import pandas as pd
-import pytz
 from pandas.io.sql import read_sql
 from metpy.units import units as mpunits
 from pyiem.plot.util import fitbox
@@ -234,8 +238,8 @@ def _time_domain_string(df, tzname):
     ets = df["valid"].max()
     timeformat = "%d %b %Y %I:%M %p"
     if tzname is not None:
-        sts = sts.astimezone(pytz.timezone(tzname))
-        ets = ets.astimezone(pytz.timezone(tzname))
+        sts = sts.astimezone(ZoneInfo(tzname))
+        ets = ets.astimezone(ZoneInfo(tzname))
     if tzname == "UTC":
         timeformat = "%d %b %Y %H:%M"
     return "%s - %s %s" % (

--- a/tests/nws/products/test_dsm.py
+++ b/tests/nws/products/test_dsm.py
@@ -2,8 +2,12 @@
 # pylint: disable=redefined-outer-name
 import datetime
 
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
+
 import pytest
-import pytz
 from pyiem.util import utc, get_test_file
 from pyiem.nws.products.dsm import process, parser
 from pyiem.util import get_dbconn
@@ -39,7 +43,7 @@ def test_simple(month):
         "00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/225/26381759/"
         "26500949="
     ) % (month,)
-    tzprovider = {"KCVG": pytz.timezone("America/New_York")}
+    tzprovider = {"KCVG": ZoneInfo("America/New_York")}
     dsm = process(text)
     dsm.compute_times(utc(2019, month, 25))
     dsm.tzlocalize(tzprovider["KCVG"])

--- a/tests/test_iemre.py
+++ b/tests/test_iemre.py
@@ -1,6 +1,10 @@
 """test IEMRE stuff"""
 import datetime
-import pytz
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 import numpy as np
 from pyiem.util import utc, get_dbconn
@@ -108,7 +112,7 @@ def test_hourly_offset():
     assert offset == 0
 
     ts = utc(2013, 1, 1, 6, 0)
-    ts = ts.astimezone(pytz.timezone("America/Chicago"))
+    ts = ts.astimezone(ZoneInfo("America/Chicago"))
     offset = iemre.hourly_offset(ts)
     assert offset == 6
 

--- a/tests/test_mrms.py
+++ b/tests/test_mrms.py
@@ -1,7 +1,7 @@
 """tests"""
 import datetime
+from datetime import timezone
 import os
-import pytz
 
 from pyiem import mrms
 from pyiem.util import utc
@@ -33,7 +33,7 @@ def test_fetch():
     fn = mrms.fetch(PRODUCT, valid, tmpdir="/tmp")
     if os.path.isfile(fn):
         os.unlink(fn)
-    valid = valid.replace(tzinfo=pytz.utc) - datetime.timedelta(minutes=2)
+    valid = valid.replace(tzinfo=timezone.utc) - datetime.timedelta(minutes=2)
     fn = mrms.fetch(PRODUCT, valid, tmpdir="/tmp")
     if os.path.isfile(fn):
         os.unlink(fn)

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,7 +1,8 @@
 """Test pyiem.tracker."""
+# pylint: disable=redefined-outer-name
 import datetime
+from datetime import timezone
 
-import pytz
 import pytest
 from pyiem.tracker import TrackerEngine, loadqc
 from pyiem.network import Table as NetworkTable
@@ -51,7 +52,7 @@ def test_workflow(pcursor, icursor):
         name="YYY Site Name", network="IA_XXXX", tzname="America/Chicago"
     )
     valid = datetime.datetime.utcnow()
-    valid = valid.replace(tzinfo=pytz.timezone("UTC"))
+    valid = valid.replace(tzinfo=timezone.utc)
     threshold = valid - datetime.timedelta(hours=3)
     obs = {
         sid1: {"valid": valid},

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,7 @@
 """Testing of util."""
 # pylint: disable=redefined-outer-name
 import datetime
+from datetime import timezone
 import string
 import random
 import logging
@@ -10,7 +11,6 @@ from collections import OrderedDict
 import mock
 
 import pytest
-import pytz
 import numpy as np
 import psycopg2
 from pyiem import util
@@ -130,10 +130,10 @@ def test_ssw():
 
 def test_utc():
     """Does the utc() function work as expected."""
-    answer = datetime.datetime(2017, 2, 1, 2, 20).replace(tzinfo=pytz.UTC)
+    answer = datetime.datetime(2017, 2, 1, 2, 20).replace(tzinfo=timezone.utc)
     res = util.utc(2017, 2, 1, 2, 20)
     assert answer == res
-    answer = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
+    answer = datetime.datetime.utcnow().replace(tzinfo=timezone.utc)
     assert answer.year == util.utc().year
 
 


### PR DESCRIPTION
The `pytz` package has served us well over the years, but python=3.9 will come with a `zoneinfo` package and there's a backported package available for all the python versions we support. 