### PR TITLE
correct is_emergency false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this library are documented in this file.
 
 ### Bug Fixes
 
+- Correct VTEC `is_emergency` false positive spotted by Kyle Noël.
+
 ## **1.15.0** (13 Feb 2023)
 
 ### API Changes

--- a/data/product_examples/TORE/TORHGX_false_positive.txt
+++ b/data/product_examples/TORE/TORHGX_false_positive.txt
@@ -1,0 +1,52 @@
+968
+WFUS54 KHGX 191141
+TORHGX
+TXC071-191215-
+/O.NEW.KHGX.TO.W.0044.190919T1141Z-190919T1215Z/
+
+BULLETIN - EAS ACTIVATION REQUESTED
+Tornado Warning
+National Weather Service Houston/Galveston TX
+641 AM CDT Thu Sep 19 2019
+
+The National Weather Service in League City has issued a
+
+* Tornado Warning for...
+  Northeastern Chambers County in southeastern Texas...
+
+* Until 715 AM CDT.
+
+* At 639 AM CDT, a severe thunderstorm capable of producing a tornado
+  was located near Winnie, or 9 miles west of Hamshire, moving
+  northeast at 15 mph. The main threat remains flash flooding, as
+  this area is in a flash flood emergency.
+
+  HAZARD...Tornado.
+
+  SOURCE...Radar indicated rotation.
+
+  IMPACT...Flying debris will be dangerous to those caught without
+           shelter. Mobile homes will be damaged or destroyed.
+           Damage to roofs, windows, and vehicles will occur.  Tree
+           damage is likely.
+
+* This dangerous storm will be near...
+  Winnie around 655 AM CDT.
+  Stowell around 700 AM CDT.
+
+PRECAUTIONARY/PREPAREDNESS ACTIONS...
+
+TAKE COVER NOW! If you are outdoors, in a mobile home, or in a
+vehicle, move to the closest substantial shelter and protect
+yourself from flying debris.
+
+&&
+
+LAT...LON 2976 9448 2984 9452 2989 9442 2989 9436
+      2978 9436
+TIME...MOT...LOC 1139Z 237DEG 14KT 2981 9446
+
+TORNADO...RADAR INDICATED
+HAIL...<.75IN
+
+$$

--- a/src/pyiem/nws/product.py
+++ b/src/pyiem/nws/product.py
@@ -346,9 +346,16 @@ class TextProductSegment:
         """Find various tags in this segment"""
         nolf = self.unixtext.replace("\n", " ")
         res = EMERGENCY_RE.findall(nolf)
-        if res:
+        if res and self.vtec:
+            # Ensure that the emergency RE matches the segment phenomena
             # We later double check this based on the found tags
-            self.is_emergency = True
+            if (
+                res[0].upper() == "FLASH FLOOD"
+                and self.vtec[0].phenomena == "FF"
+            ):
+                self.is_emergency = True
+            if res[0].upper() == "TORNADO" and self.vtec[0].phenomena == "TO":
+                self.is_emergency = True
         res = PDS_RE.findall(nolf)
         if res:
             self.is_pds = True

--- a/tests/nws/products/test_products_vtec.py
+++ b/tests/nws/products/test_products_vtec.py
@@ -40,6 +40,12 @@ def filter_warnings(ar, startswith="get_gid"):
     return [a for a in ar if not a.startswith(startswith)]
 
 
+def test_230217_tore_false_positive():
+    """Test that this event is not an emergency."""
+    prod = _vtecparser(get_test_file("TORE/TORHGX_false_positive.txt"))
+    assert not prod.segments[0].is_emergency
+
+
 @pytest.mark.parametrize("database", ["postgis"])
 def test_flwmtr_dueling_etns(dbcursor):
     """Test that we can properly juggle dueling ETNs over 1 Jan."""


### PR DESCRIPTION
The issue was having "Flash Flood Emergency" in the text of a tornado warning.  This adds a cross check that these match.