### PR TITLE
drop python3.8 because of pandas=2 + xarray

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PYTHON_VERSION: ["3.8", "3.10", "3.11"]
+        PYTHON_VERSION: ["3.9", "3.10", "3.11"]
     env:
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
     steps:
@@ -43,14 +43,14 @@ jobs:
         cd ..
 
     - name: Code coverage
-      if: ${{ matrix.PYTHON_VERSION == '3.8' }}
+      if: ${{ matrix.PYTHON_VERSION == '3.10' }}
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.xml
 
     - name: Build and Deploy
-      if: ${{ matrix.PYTHON_VERSION == '3.8' }}
+      if: ${{ matrix.PYTHON_VERSION == '3.10' }}
       uses: JamesIves/github-pages-deploy-action@releases/v3
       with:
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this library are documented in this file.
 
 ### API Changes
 
+- Dropped python=3.8 support/testing as xarray has moved on.
 - Removed `pyiem.cscap_utils` as it was not maintained.
 - Removed `pyiem.twistedpg` as it was a glorious hack and no longer needed.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Current release info
 Dependencies
 ------------
 
-Python releases 3.8 through 3.10 are actively tested and supported within this repository.
+Python releases 3.9 through 3.11 are actively tested and supported within this repository.
 
 The codebase currently makes direct database calls with hardcoded assumptions
 of the hostname `iemdb.local` and database names.  Someday, I'll use a proper ORM

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -21,7 +21,7 @@ mock
 ncurses
 netCDF4
 numpy
-pandas>=2
+pandas
 # geoplot usage
 pillow
 psycopg2

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -21,7 +21,7 @@ mock
 ncurses
 netCDF4
 numpy
-pandas
+pandas>=2
 # geoplot usage
 pillow
 psycopg2

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -43,8 +43,7 @@ requests
 # interpolation
 scipy
 shapely
-# pinned down due to pandas compat
-sqlalchemy<2
+sqlalchemy
 twython
 # iemre
 xarray

--- a/tests/nws/test_bufkit.py
+++ b/tests/nws/test_bufkit.py
@@ -24,7 +24,7 @@ def test_values():
     """Test that we get values we expect."""
     fp = get_test_filepath("BUFKIT/namm_kdsm.buf")
     sndf, stndf = read_bufkit(fp)
-    row = sndf[(sndf["STIM"] == 0) & (sndf["PRES"] == 7.60)]
+    row = sndf[(sndf["STIM"] == 0) & (sndf["PRES"] == 7.60)].iloc[0]
     assert abs(float(row["HGHT"]) - 33326.51) < 0.01
     row = stndf.loc[84]
     assert abs(float(row["TD2M"]) - 15.79) < 0.01


### PR DESCRIPTION
xarray update was released today, so we should be good to go now.