### PR TITLE
Prevent CF6 data from the future

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     - id: black
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.270"
+    rev: "v0.0.275"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this library are documented in this file.
 - Correct VTEC `is_emergency` false positive spotted by Kyle Noël.
 - Improve forgiveness of CLI parser some more.  Never ends.
 - Improve robustness of `FLS` impacts bullet search.
+- Prevent CF6 data from the future.
 - [SHEF] Workaround `DV` months offset, which is ill-defined anyway.
 - Support LSRs with mile units.
 - Fix LSR `typetext` comparisons and ensure database uppercase entries.

--- a/data/product_examples/CF6/CF6ANC.txt
+++ b/data/product_examples/CF6/CF6ANC.txt
@@ -1,0 +1,99 @@
+318 
+CXAK56 PAFC 261626
+CF6ANC
+PRELIMINARY LOCAL CLIMATOLOGICAL DATA (WS FORM: F-6)
+
+                                          STATION:   ANCHORAGE AK
+                                          MONTH:     JUNE
+                                          YEAR:      2023
+                                          LATITUDE:   61 10 N      
+                                          LONGITUDE: 150  2 W    
+
+  TEMPERATURE IN F:       :PCPN:    SNOW:  WIND      :SUNSHINE: SKY     :PK WND 
+================================================================================
+1   2   3   4   5  6A  6B    7    8   9   10  11  12  13   14  15   16   17  18
+                                     12Z  AVG MX 2MIN
+DY MAX MIN AVG DEP HDD CDD  WTR  SNW DPTH SPD SPD DIR MIN PSBL S-S WX    SPD DR
+================================================================================
+
+ 1  55  43  49  -3  16   0 0.11  0.0    0 13.6 23 150   M    M   9        35 180
+ 2  49  44  47  -6  18   0 0.02  0.0    0 15.5 22 150   M    M  10        32 160
+ 3  56  46  51  -2  14   0    T  0.0    0 11.2 20 140   M    M  10        29 190
+ 4  60  45  53   0  12   0 0.00  0.0    0  6.9 20 300   M    M   8        34 150
+ 5  69  44  57   3   8   0 0.00  0.0    0 11.0 29 160   M    M   7        42 140
+ 6  57  50  54   0  11   0 0.02  0.0    0  8.6 28 150   M    M   9        37 160
+ 7  56  48  52  -2  13   0 0.02  0.0    0  3.5 13 160   M    M   9        25 160
+ 8  59  49  54   0  11   0    T  0.0    0  7.5 20 150   M    M  10        30 150
+ 9  61  50  56   1   9   0    T  0.0    0 14.2 30 150   M    M   8        41 150
+10  60  47  54  -1  11   0 0.05  0.0    0 13.1 25 140   M    M   8        39 140
+11  56  47  52  -3  13   0    T  0.0    0 11.8 29 150   M    M   8        41 160
+12  54  43  49  -6  16   0 0.22  0.0    0 11.4 22 160   M    M   8 1      33 170
+13  54  43  49  -7  16   0 0.01  0.0    0 10.2 17 150   M    M   8        36 160
+14  58  47  53  -3  12   0 0.00  0.0    0 14.3 26 150   M    M   8        37 150
+15  54  44  49  -7  16   0 0.01  0.0    0  5.4 13 160   M    M   8        22 160
+16  55  46  51  -5  14   0 0.04  0.0    0  7.3 13 160   M    M   9        26 170
+17  61  42  52  -4  13   0 0.00  0.0    0  4.6 12 310   M    M   6        17 290
+18  72  46  59   2   6   0 0.00  0.0    0  4.5 12 250   M    M   4        15 240
+19  64  50  57   0   8   0    T  0.0    0  4.3 13 200   M    M   8        17 210
+20  60  53  57   0   8   0 0.42  0.0    0  1.8  9  30   M    M  10 1      12  30
+21  62  54  58   1   7   0 0.06  0.0    0  4.1 20 140   M    M   9 1      29 140
+22  66  55  61   4   4   0 0.02  0.0    0  8.8 21 150   M    M   9        34 170
+23  68  53  61   3   4   0 0.03  0.0    0  9.1 22 150   M    M   8        40 160
+24  69  56  63   5   2   0 0.00  0.0    0 11.4 25 150   M    M   8        36 140
+25  63  53  58   0   7   0 0.01  0.0    0 17.1 29 150   M    M   7        44 140
+26   M   M   M   M   M   M    M    M    M    M  M   M   M    M   M         M   M
+27   M   M   M   M   M   M    M    M    M    M  M   M   M    M   M         M   M
+28   M   M   M   M   M   M    M    M    M    M  M   M   M    M   M         M   M
+29   M   M   M   M   M   M    M    M    M    M  M   M   M    M   M         M   M
+30   M   M   M   M   M   M    M    M    M    M  M   M   M    M   M         M   M
+================================================================================
+SM 1498 1198       269   0  1.04  0.0    231.2          M      206              
+================================================================================
+AV 59.9 47.9                               9.2 FASTST   M    M   8    MAX(MPH)  
+                                 MISC ---->    30 150                 44 140   
+================================================================================
+NOTES:
+# LAST OF SEVERAL OCCURRENCES
+
+COLUMN 17 PEAK WIND IN M.P.H.
+
+PRELIMINARY LOCAL CLIMATOLOGICAL DATA (WS FORM: F-6) , PAGE 2
+
+                                          STATION:   ANCHORAGE AK
+                                          MONTH:     JUNE
+                                          YEAR:      2023
+                                          LATITUDE:   61 10 N      
+                                          LONGITUDE: 150  2 W                   
+
+[TEMPERATURE DATA]      [PRECIPITATION DATA]       SYMBOLS USED IN COLUMN 16    
+
+AVERAGE MONTHLY: 53.9   TOTAL FOR MONTH:   1.04    1 = FOG OR MIST              
+DPTR FM NORMAL:  -2.0   DPTR FM NORMAL:    0.02    2 = FOG REDUCING VISIBILITY  
+HIGHEST:    72 ON 18    GRTST 24HR  0.44 ON 20-21      TO 1/4 MILE OR LESS      
+LOWEST:     42 ON 17                               3 = THUNDER                  
+                        SNOW, ICE PELLETS, HAIL    4 = ICE PELLETS              
+                        TOTAL MONTH:   0.0 INCH    5 = HAIL                     
+                        GRTST 24HR  0.0            6 = FREEZING RAIN OR DRIZZLE 
+                        GRTST DEPTH:  0            7 = DUSTSTORM OR SANDSTORM:  
+                                                       VSBY 1/2 MILE OR LESS    
+                                                   8 = SMOKE OR HAZE            
+[NO. OF DAYS WITH]      [WEATHER - DAYS WITH]      9 = BLOWING SNOW             
+                                                   X = TORNADO                  
+MAX 32 OR BELOW:   0    0.01 INCH OR MORE:  14                      
+MAX 90 OR ABOVE:   0    0.10 INCH OR MORE:   3                      
+MIN 32 OR BELOW:   0    0.50 INCH OR MORE:   0                      
+MIN  0 OR BELOW:   0    1.00 INCH OR MORE:   0                        
+
+[HDD (BASE 65) ]                                                                
+TOTAL THIS MO.   269    CLEAR  (SCALE 0-3)   0                                  
+DPTR FM NORMAL    -6    PTCLDY (SCALE 4-7)  12                                  
+TOTAL FM JUL 1 10111    CLOUDY (SCALE 8-10) 13                                  
+DPTR FM NORMAL   130                                                            
+
+[CDD (BASE 65) ]                                                                
+TOTAL THIS MO.     0                                                            
+DPTR FM NORMAL    -2    [PRESSURE DATA]                                         
+TOTAL FM JAN 1     0    HIGHEST SLP M ON M        
+DPTR FM NORMAL    -2    LOWEST  SLP 29.37 ON 16        
+
+[REMARKS]

--- a/src/pyiem/nws/products/cf6.py
+++ b/src/pyiem/nws/products/cf6.py
@@ -105,6 +105,12 @@ class CF6Product(TextProduct):
         df["valid"] = df["dy"].apply(
             lambda x: datetime.date(day1.year, day1.month, int(x))
         )
+        # Ensure we don't have data from utcnow + 1 day
+        ceiling = (self.utcnow + datetime.timedelta(days=1)).date()
+        indicies = pd.to_datetime(df["valid"]) > pd.Timestamp(ceiling)
+        if indicies.any():
+            self.warnings.append(f"{indicies.sum()} rows from the future")
+            df = df.loc[~indicies]
         self.df = df.set_index("valid")
 
     def sql(self, cursor):

--- a/tests/nws/products/test_cf6.py
+++ b/tests/nws/products/test_cf6.py
@@ -4,7 +4,16 @@ import datetime
 import pytest
 from pyiem.nws.products.cf6 import parser
 from pyiem.reference import TRACE_VALUE
-from pyiem.util import get_test_file
+from pyiem.util import get_test_file, utc
+
+
+def test_230628_future():
+    """Test the exclusion of data from the future!"""
+    # Data from the 27th is taken as it is tricky to get this perfect
+    utcnow = utc(2023, 6, 26, 16, 26)
+    prod = parser(get_test_file("CF6/CF6ANC.txt"), utcnow=utcnow)
+    assert prod.warnings
+    assert len(prod.df.index) == 27
 
 
 @pytest.mark.parametrize("database", ["iem"])


### PR DESCRIPTION
Sometimes CF6 data has data [from the future](https://mesonet.agron.iastate.edu/wx/afos/p.php?pil=CF6ANC&e=202306261626) and it causes grief for downstream apps.