### PR TITLE
fix: edge case logic in grid.zs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ need little default processing.  `pyiem.nws.product.TextProduct` inherits.
 - Fix `iemre.reproject2iemre` to return a masked_array and handle an input
 masked array.
 - Fix invalid `rtrim()` usage with `removesuffix()`.
+- Fix off-by-one when `grid.zs` hits a mask right at the border.
 - Improve `setuptools_scm` plumbing to avoid runtime import.
 - Support a variant `Trace` value specified in LSRs.
 

--- a/src/pyiem/grid/zs.py
+++ b/src/pyiem/grid/zs.py
@@ -65,7 +65,7 @@ class CachingZonalStats:
                 mask = mask[:, abs(x0) :]
                 xsz -= abs(x0)
                 x0 = 0
-            if (x0 + xsz) >= gridxsz:
+            if (x0 + xsz) > gridxsz:
                 clipx = (x0 + xsz) - gridxsz
                 LOG.debug("clipping %s x points", clipx)
                 mask = mask[:, : (0 - clipx)]
@@ -74,7 +74,7 @@ class CachingZonalStats:
                 mask = mask[abs(y0) :, :]
                 ysz -= abs(y0)
                 y0 = 0
-            if (y0 + ysz) >= gridysz:
+            if (y0 + ysz) > gridysz:
                 clipy = (y0 + ysz) - gridysz
                 LOG.debug("clipping %s y points", clipy)
                 mask = mask[: (0 - clipy), :]


### PR DESCRIPTION
Did not impact any computations, just an edge case when the mask is right at the border.