### PR TITLE
fix: prevent open-ended VTEC database search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ need little default processing.  `pyiem.nws.product.TextProduct` inherits.
 
 ### Bug Fixes
 
+- Constrain a VTEC database search for expiration times not infinitely into
+the future.
 - Fix `iemre.reproject2iemre` to return a masked_array and handle an input
 masked array.
 - Fix invalid `rtrim()` usage with `removesuffix()`.

--- a/data/product_examples/WSWDMX/WSW_N1.txt
+++ b/data/product_examples/WSWDMX/WSW_N1.txt
@@ -1,0 +1,57 @@
+943 
+WWUS43 KDMX 070940
+WSWDMX
+
+URGENT - WINTER WEATHER MESSAGE
+National Weather Service Des Moines IA
+340 AM CST Sun Jan 7 2024
+
+...Moderate to Heavy Snow Monday and Tuesday...
+
+.Moderate to heavy heavy snow will spread across Iowa from very 
+early Monday morning and last into Tuesday. Highest accumulations 
+will occur across parts of southern Iowa where widespread amounts
+of 6 to 10 inches or more may occur. As snow ends Tuesday 
+afternoon, winds will increase with gusts of 35 to 40 mph or
+greater possible. This could result in a period of blowing and 
+drifting snow.
+
+IAZ038-039-044>050-057>062-070>074-071745-
+/O.EXA.KDMX.WS.A.0001.240108T1200Z-240110T0000Z/
+Grundy-Black Hawk-Crawford-Carroll-Greene-Boone-Story-Marshall-
+Tama-Audubon-Guthrie-Dallas-Polk-Jasper-Poweshiek-Cass-Adair-
+Madison-Warren-Marion-
+Including the cities of Grundy Center, Reinbeck, Conrad, Dike, 
+Wellsburg, Waterloo, Cedar Falls, Denison, Carroll, Jefferson, 
+Boone, Ames, Marshalltown, Tama, Toledo, Traer, Dysart, 
+Gladbrook, Audubon, Exira, Guthrie Center, Panora, Bayard, Casey,
+Perry, Waukee, Adel, Des Moines, Newton, Grinnell, Atlantic, 
+Greenfield, Stuart, Adair, Fontanelle, Winterset, Earlham, 
+Indianola, Norwalk, Carlisle, Pella, and Knoxville
+340 AM CST Sun Jan 7 2024
+
+...WINTER STORM WATCH IN EFFECT FROM MONDAY MORNING THROUGH
+TUESDAY AFTERNOON...
+
+* WHAT...Heavy snow possible. Total snow accumulations of 4 to 8
+  inches possible. Winds could gust up to around 40 mph by Tuesday
+  afternoon and evening and cause periods of drifting and blowing
+  snow.
+
+* WHERE...Central Iowa.
+
+* WHEN...From Monday morning through Tuesday afternoon.
+
+* IMPACTS...Travel could be very difficult. The hazardous
+  conditions will likely impact the morning and evening commutes.
+
+PRECAUTIONARY/PREPAREDNESS ACTIONS...
+
+Monitor the latest forecasts for updates on this situation. 
+
+If travel must be done, be sure to have an winter car kit and
+follow check 511ia.org for road conditions. 
+
+&&
+
+$$

--- a/src/pyiem/nws/products/_vtec_util.py
+++ b/src/pyiem/nws/products/_vtec_util.py
@@ -65,7 +65,7 @@ def which_year(txn, prod, segment, vtec):
             min(issue at time zone 'UTC') as min_issue from warnings
             WHERE wfo = %s and eventid = %s and significance = %s and
             phenomena = %s and ((updated > %s and updated <= %s)
-            or expire > %s) and status not in ('UPG', 'CAN')
+            or (expire > %s and expire < %s)) and status not in ('UPG', 'CAN')
             GROUP by tablename, hvtec_nwsli ORDER by tablename DESC
             """,
             (
@@ -76,6 +76,7 @@ def which_year(txn, prod, segment, vtec):
                 prod.valid - timedelta(days=offset),
                 prod.valid,
                 prod.valid,
+                prod.valid + timedelta(days=31),  # life choices
             ),
         )
         rows = txn.fetchall()

--- a/tests/nws/products/test_products_vtec.py
+++ b/tests/nws/products/test_products_vtec.py
@@ -1701,6 +1701,10 @@ def test_141205_vtec_series(dbcursor):
 @pytest.mark.parametrize("database", ["postgis"])
 def test_vtec_series(dbcursor):
     """Test a lifecycle of WSW products"""
+    # This is from 2024, which will exercise an archive search
+    prod = vtecparser(get_test_file("WSWDMX/WSW_N1.txt"))
+    prod.sql(dbcursor)
+
     prod = vtecparser(get_test_file("WSWDMX/WSW_00.txt"))
     assert prod.afos == "WSWDMX"
     prod.sql(dbcursor)


### PR DESCRIPTION
This would cause reprocessing of old data to show up in the current year table, gasp, sigh, bad daryl.