### PR TITLE
🎨 Raise BadWebRequest on list provided to autoplot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this library are documented in this file.
 ### Bug Fixes
 
 - Add preflight check of MOS database write for known column storage.
+- Improve enforcement of str types into autoplot context parsing.
 - Support `with_sqlalchemy_conn` to decorate a generator.
 
 ## **1.27.0** (14 Apr 2026)

--- a/src/pyiem/autoplot.py
+++ b/src/pyiem/autoplot.py
@@ -4,7 +4,11 @@ import re
 from datetime import date, datetime, timedelta
 from html import escape
 
-from pyiem.exceptions import IncompleteWebRequest, UnknownStationException
+from pyiem.exceptions import (
+    BadWebRequest,
+    IncompleteWebRequest,
+    UnknownStationException,
+)
 from pyiem.network import Table as NetworkTable
 from pyiem.reference import state_names
 
@@ -258,6 +262,16 @@ def _process_option(
     maxval = opt.get("max", DEFAULT_MAXVAL.get(typ))
     optional: bool = opt.get("optional", False)
     value: str | None = fdict.get(name)
+    # value needs to be either None or `str` type, anything else is a problem
+    if (
+        not opt.get("multiple", False)
+        and value is not None
+        and not isinstance(value, str)
+    ):
+        raise BadWebRequest(
+            f"Invalid value for parameter: {name} of type: {type(value)}, "
+            "expected a string."
+        )
     # vtec_ps is special since we have special logic to get its value
     if (
         optional

--- a/src/pyiem/autoplot.py
+++ b/src/pyiem/autoplot.py
@@ -261,7 +261,7 @@ def _process_option(
     minval = opt.get("min", DEFAULT_MINVAL.get(typ))
     maxval = opt.get("max", DEFAULT_MAXVAL.get(typ))
     optional: bool = opt.get("optional", False)
-    value: str | None = fdict.get(name)
+    value: str | list[str] | None = fdict.get(name)
     # value needs to be either None or `str` type, anything else is a problem
     if (
         not opt.get("multiple", False)

--- a/tests/test_autoplot.py
+++ b/tests/test_autoplot.py
@@ -5,7 +5,19 @@ from datetime import date, datetime
 import pytest
 
 from pyiem.autoplot import get_autoplot_context
-from pyiem.exceptions import IncompleteWebRequest, UnknownStationException
+from pyiem.exceptions import (
+    BadWebRequest,
+    IncompleteWebRequest,
+    UnknownStationException,
+)
+
+
+def test_value_provided_is_a_list():
+    """Test that we don't allow this GIGO to have downstream bugs."""
+    form = {"month": ["1", "2"]}
+    cfg = {"arguments": [{"type": "month", "name": "month", "default": 1}]}
+    with pytest.raises(BadWebRequest):
+        get_autoplot_context(form, cfg)
 
 
 def test_invalid_month():
@@ -412,7 +424,7 @@ def test_get_autoplot_context_dates():
 
 def test_get_autoplot_context_optional():
     """Test that we require the optional flag nomenclature."""
-    form = dict(year=2011)
+    form = {"year": "2011"}
     opts = dict(
         arguments=[
             dict(type="year", name="year", optional=True, default=2012),


### PR DESCRIPTION
This tightens when lists of strings are allowed into autoplot context parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved enforcement of string types during context parameter validation, providing stricter input validation for form submissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akrherz/pyIEM/pull/1207)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->