### PR TITLE
Revert "🎨 Use dedicated socket for telemetry logging"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ All notable changes to this library are documented in this file.
 - Disable IEMAccess write of wind information from the DSM due to inprecision
   of reported units in MPH.
 - Return signature of `str2multipolygon` changed to include a list of errors.
-- `webutil.write_telemetry` now writes to dedicated socket
-  `/run/rsyslog/telemetry.sock` with
+- `webutil.write_telemetry` now writes to syslog (local1.info) with
   `webutil.TELEMETRY_PREFIX` and a JSON payload string.
 
 ### New Features

--- a/src/pyiem/webutil.py
+++ b/src/pyiem/webutil.py
@@ -7,9 +7,9 @@ import json
 import os
 import random
 import re
-import socket
 import string
 import sys
+import syslog
 import traceback
 import warnings
 from collections import namedtuple
@@ -77,7 +77,6 @@ TELEMETRY = namedtuple(
     ],
 )
 TELEMETRY_PREFIX = "Telemetry "
-TELEMETRY_SOCKET = "/run/rsyslog/telemetry.sock"
 XSS_SENTINEL = "XSS"
 MEMCACHED_HIT = "_mhit"
 
@@ -206,18 +205,19 @@ equivalent to ``?foo=1,2``.
 
 
 def write_telemetry(data: TELEMETRY) -> bool:
-    """Best-effort telemetry write."""
-    payload = (
-        TELEMETRY_PREFIX
-        + json.dumps(data._asdict(), separators=(",", ":"), sort_keys=True)
-    ).encode("utf-8")
-    # We need to avoid syslog as systemd/journal will intercept this and
-    # fill logs quickly.
+    """Write telemetry to syslog."""
     try:
-        with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as sock:
-            sock.setblocking(False)
-            sock.sendto(payload, TELEMETRY_SOCKET)
-    except (BlockingIOError, OSError):
+        syslog.syslog(
+            syslog.LOG_LOCAL1 | syslog.LOG_INFO,
+            TELEMETRY_PREFIX
+            + json.dumps(
+                data._asdict(),
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+        )
+    except Exception as exp:
+        LOG.info("write_telemetry failed: %s", exp, exc_info=True)
         return False
     return True
 

--- a/tests/test_webutil.py
+++ b/tests/test_webutil.py
@@ -20,7 +20,6 @@ from pyiem.exceptions import (
 from pyiem.reference import ISO8601
 from pyiem.webutil import (
     TELEMETRY,
-    TELEMETRY_SOCKET,
     CGIModel,
     ListOrCSVType,
     _is_xss_payload,
@@ -553,39 +552,23 @@ def test_disable_parse_times():
 
 
 def test_add_telemetry():
-    """Test adding something to the telemetry socket."""
-    data = TELEMETRY(
-        timing=1,
-        status_code=200,
-        client_addr=None,
-        app="test",
-        request_uri="",
-        vhost="",
-        valid=datetime.now().strftime(ISO8601),
-    )
-    socket_mock = mock.MagicMock()
-    cm_mock = mock.MagicMock()
-    cm_mock.__enter__.return_value = socket_mock
-    cm_mock.__exit__.return_value = False
-    with mock.patch("pyiem.webutil.socket.socket", return_value=cm_mock):
-        assert write_telemetry(data)
-
-    socket_mock.setblocking.assert_called_once_with(False)
-    socket_mock.sendto.assert_called_once_with(
-        b"Telemetry "
-        + (
-            b'{"app":"test","client_addr":null,"request_uri":"",'
-            b'"status_code":200,"timing":1,"valid":"'
-            + data.valid.encode("utf-8")
-            + b'","vhost":""}'
+    """Test adding something to the queue."""
+    assert write_telemetry(
+        TELEMETRY(
+            timing=1,
+            status_code=200,
+            client_addr=None,
+            app="test",
+            request_uri="",
+            vhost="",
+            valid=datetime.now().strftime(ISO8601),
         ),
-        TELEMETRY_SOCKET,
     )
 
 
 def test_add_telemetry_failure_is_swallowed():
     """Test telemetry failures stay contained inside write_telemetry."""
-    with mock.patch("pyiem.webutil.socket.socket", side_effect=OSError()):
+    with mock.patch("pyiem.webutil.syslog.syslog", side_effect=RuntimeError()):
         assert not write_telemetry(
             TELEMETRY(
                 timing=1,


### PR DESCRIPTION
This reverts commit 231dad2604a146b3d1bfe79cf3f6b51b0aabab05.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Telemetry is now logged to syslog (`local1.info`) instead of a dedicated socket.

* **Tests**
  * Updated telemetry tests to align with the new syslog-based logging mechanism.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akrherz/pyIEM/pull/1213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->