### PR TITLE
🐛 Update now-defunct go.usa URL to NHC direct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this library are documented in this file.
 - Add preflight check of MOS database write for known column storage.
 - Improve enforcement of str types into autoplot context parsing.
 - Support `with_sqlalchemy_conn` to decorate a generator.
+- Update NHC website link due to now-defunct URL shortener service.
 
 ## **1.27.0** (14 Apr 2026)
 

--- a/src/pyiem/nws/products/nhc.py
+++ b/src/pyiem/nws/products/nhc.py
@@ -40,7 +40,7 @@ class NHCProduct(TextProduct):
         tformat = (
             "%(classification)s #%(storm_name)s "
             "%(btype)s %(num)s issued. %(headline)s "
-            "http://go.usa.gov/W3H"
+            "https://www.nhc.noaa.gov/#%(storm_name)s"
         )
         tdict = {
             "classification": classification.title(),

--- a/tests/nws/test_products.py
+++ b/tests/nws/test_products.py
@@ -242,7 +242,7 @@ def test_tcp():
         "Post-Tropical Cyclone "
         "#Arthur ADVISORY 19 issued. Strong winds and heavy rains to "
         "continue over portions of southeastern canada through tonight. "
-        "http://go.usa.gov/W3H"
+        "https://www.nhc.noaa.gov/#Arthur"
     )
     assert j[0][2]["twitter"] == ans
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated NHC website link in product output to use a functional URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->