### PR TITLE
CLI parsing improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,13 +2,13 @@ ci:
   autoupdate_schedule: quarterly
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.20"
+    rev: "v0.15.22"
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 'v2.25.1'
+    rev: 'v2.25.3'
     hooks:
       - id: pyproject-fmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this library are documented in this file.
 
 - Account for `CNCL` as a cancellation string in `CWA` products.
 - Add preflight check of MOS database write for known column storage.
+- Handle `M` in CLI parsing as missing, improve log message.
 - Improve enforcement of str types into autoplot context parsing.
 - Support `with_sqlalchemy_conn` to decorate a generator.
 - Update NHC website link due to now-defunct URL shortener service.

--- a/data/product_examples/CLI/CLIDCA.txt
+++ b/data/product_examples/CLI/CLIDCA.txt
@@ -1,0 +1,98 @@
+337 
+CDUS41 KLWX 290640
+CLIDCA
+
+CLIMATE REPORT 
+NATIONAL WEATHER SERVICE BALTIMORE MD/WASHINGTON DC 
+240 AM EDT MON JUN 29 2026
+
+...................................
+
+...THE WASHINGTON NATIONAL DC CLIMATE SUMMARY FOR JUNE 28 2026...
+
+CLIMATE NORMAL PERIOD: 1991 TO 2020
+CLIMATE RECORD PERIOD: 1871 TO 2026
+
+
+WEATHER ITEM   OBSERVED TIME   RECORD YEAR NORMAL DEPARTURE LAST      
+                VALUE   (LST)  VALUE       VALUE  FROM      YEAR     
+                                                  NORMAL           
+...................................................................
+TEMPERATURE (F)                                                          
+ YESTERDAY                                                           
+  MAXIMUM         76   6:27 PM 100    1969  89    -13       88        
+  MINIMUM         72   8:46 AM  54    1927  71      1       71        
+  AVERAGE         55                        80     -6       80     
+
+PRECIPITATION (IN)                                                    
+  YESTERDAY        0.33          2.95 1914   0.15   0.18     0.00     
+  MONTH TO DATE    1.68                      3.90  -2.22     5.48     
+  SINCE JUN 1      1.68                      3.90  -2.22     5.48     
+  SINCE JAN 1     13.71                     20.03  -6.32    23.52     
+
+SNOWFALL (IN)                                                              
+  YESTERDAY        0.0           MM      MM   0.0   MM        0.0      
+  MONTH TO DATE    0.0                       0.0    0.0      0.0      
+  SINCE JUN 1      0.0                       0.0    0.0      0.0      
+  SINCE JUL 1     10.6                      13.7   -3.1     14.9      
+  SNOW DEPTH         0                                                  
+
+DEGREE DAYS                                                           
+ HEATING                                                              
+  YESTERDAY       10                         0     10        0        
+  MONTH TO DATE   10                         2      8        8        
+  SINCE JUN 1     10                         2      8        8        
+  SINCE JUL 1   3877                      3768    109     3299        
+
+ COOLING                                                              
+  YESTERDAY        0                        15    -15       15        
+  MONTH TO DATE  348                       312     36      336        
+  SINCE JUN 1    348                       312     36      336        
+  SINCE JAN 1    572                       479     93      537        
+...................................................................
+
+
+WIND (MPH)                                                            
+  HIGHEST WIND SPEED    13   HIGHEST WIND DIRECTION     N (20)        
+  HIGHEST GUST SPEED    21   HIGHEST GUST DIRECTION     N (20)        
+  AVERAGE WIND SPEED     5.9                                        
+
+
+SKY COVER                                                             
+  AVERAGE SKY COVER 0.9                                                 
+
+
+WEATHER CONDITIONS                                                    
+THE FOLLOWING WEATHER WAS RECORDED YESTERDAY.                         
+  LIGHT RAIN                                                          
+  FOG                                                                 
+
+
+RELATIVE HUMIDITY (PERCENT)
+ HIGHEST    97           8:00 AM                                      
+ LOWEST     84           6:00 PM                                      
+ AVERAGE    91                                                        
+
+..........................................................
+
+
+THE WASHINGTON NATIONAL DC CLIMATE NORMALS FOR TODAY
+                         NORMAL    RECORD    YEAR                     
+ MAXIMUM TEMPERATURE (F)   89       104      2012                      
+ MINIMUM TEMPERATURE (F)   71        54      1888                      
+
+
+SUNRISE AND SUNSET                                                    
+JUNE 29 2026..........SUNRISE   5:46 AM EDT   SUNSET   8:37 PM EDT     
+JUNE 30 2026..........SUNRISE   5:46 AM EDT   SUNSET   8:37 PM EDT     
+
+
+-  INDICATES NEGATIVE NUMBERS.
+R  INDICATES RECORD WAS SET OR TIED.
+MM INDICATES DATA IS MISSING.
+T  INDICATES TRACE AMOUNT.
+
+
+
+
+$$

--- a/src/pyiem/nws/products/cli.py
+++ b/src/pyiem/nws/products/cli.py
@@ -159,14 +159,14 @@ def get_number_year(text):
     return val
 
 
-def get_number(text):
+def get_number(text: str | None):
     """Convert a string into a number, preferable a float!"""
     if text is None:
         return None
     text = text.strip()
     if text == "":
         retval = None
-    elif text == "MM":
+    elif text in ["MM", "M"]:
         retval = None
     elif text == "T":
         retval = TRACE_VALUE
@@ -178,7 +178,7 @@ def get_number(text):
             else:
                 retval = int(number[0])
         else:
-            LOG.warning("get_number() failed for |%s|", text)
+            LOG.warning("pyiem CLI get_number() failed for |%s|", text)
             retval = None
     return retval
 

--- a/src/pyiem/nws/products/cli.py
+++ b/src/pyiem/nws/products/cli.py
@@ -502,6 +502,9 @@ class CLIProduct(TextProduct):
         self, text, utcnow=None, ugc_provider=None, nwsli_provider=None
     ):
         """constructor"""
+        # Prevent an un-necessary database load of UGCs
+        if ugc_provider is None:
+            ugc_provider = {}
         super().__init__(text, utcnow, ugc_provider, nwsli_provider)
         # Hold our parsing results as an array of dicts
         self.data = []

--- a/tests/nws/products/test_cli.py
+++ b/tests/nws/products/test_cli.py
@@ -11,6 +11,7 @@ from pyiem.reference import TRACE_VALUE, StationAttributes
 from pyiem.util import get_test_file, utc
 
 NWSLI_PROVIDER = {
+    "KDCA": dict(name="WASHINGTON DULLES", access_network="ZZ_ASOS"),
     "KIAD": dict(name="HOUSTON INTERCONTINENTAL", access_network="ZZ_ASOS"),
     "KDMH": dict(
         name="", attributes={StationAttributes.MAPS_TO: "QQQ|ZZ_ASOS"}
@@ -31,6 +32,12 @@ NWSLI_PROVIDER = {
 def factory(fn):
     """Common cliparser logic."""
     return cliparser(get_test_file(fn), nwsli_provider=NWSLI_PROVIDER)
+
+
+def test_260717_get_number(caplog):
+    """Test that no logging message is generated for this CLI."""
+    cliparser(get_test_file("CLI/CLIDCA.txt"), nwsli_provider=NWSLI_PROVIDER)
+    assert caplog.text == ""
 
 
 def test_241020_2007cli():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI parsing now correctly recognizes both `M` and `MM` as missing values.
  * Improved warning messages for ambiguous numeric values.
  * Avoided unnecessary loading when location metadata is unavailable.

* **Documentation**
  * Added an example Washington, D.C. climate report covering June 28–29, 2026.
  * Updated the unreleased changelog with the CLI parsing correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->