### PR TITLE
🐛 Workaround longlat grb2iemre grid starting at 0°

### DIFF
--- a/src/pyiem/iemre.py
+++ b/src/pyiem/iemre.py
@@ -351,6 +351,11 @@ def grb2iemre(grb, resampling=None, domain: str = "conus") -> np.ndarray:
         dy = dx
         if grb["jScansNegatively"] == 1:
             dy = -dy
+        # Ugly situation here for data that starts at 0° and goes to 360°
+        vals = grb.values
+        if llx == 0:
+            vals = np.roll(vals, vals.shape[1] // 2, axis=1)
+            llx = -180.0
         aff = Affine(
             dx,
             0.0,
@@ -359,7 +364,6 @@ def grb2iemre(grb, resampling=None, domain: str = "conus") -> np.ndarray:
             dy,
             lly + dy / 2.0,
         )
-        vals = grb.values
     else:
         aff = Affine(
             grb["DxInMetres"],

--- a/src/pyiem/iemre.py
+++ b/src/pyiem/iemre.py
@@ -353,7 +353,9 @@ def grb2iemre(grb, resampling=None, domain: str = "conus") -> np.ndarray:
             dy = -dy
         # Ugly situation here for data that starts at 0° and goes to 360°
         vals = grb.values
-        if llx == 0:
+        if np.isclose(llx, 0.0) and np.isclose(
+            vals.shape[1] * abs(dx), 360.0, atol=1
+        ):
             vals = np.roll(vals, vals.shape[1] // 2, axis=1)
             llx = -180.0
         aff = Affine(

--- a/tests/test_iemre.py
+++ b/tests/test_iemre.py
@@ -23,10 +23,20 @@ def test_d2l():
     assert iemre.d2l("europe") == "iemre_europe"
 
 
+def test_grb2iemre_cfs_conus():
+    """Test that we don't get bad values for CFS 2 CONUS IEMRE."""
+    grbs = pygrib.open(get_test_filepath("grib/cfstmpk.grib2"))
+    res = np.ma.masked_array(iemre.grb2iemre(grbs[1], domain="conus"))
+    # There should not be any masked values
+    assert not res.mask.any()
+
+
 def test_grb2iemre_cfs():
     """Test that the CFS data can work with grb2iemre."""
     grbs = pygrib.open(get_test_filepath("grib/cfstmpk.grib2"))
-    res = iemre.grb2iemre(grbs[1], domain="china")
+    res = np.ma.masked_array(iemre.grb2iemre(grbs[1], domain="china"))
+    # There should not be any masked values
+    assert not res.mask.any()
     nav = get_nav("iemre", "china")
     assert res.shape == (nav.ny, nav.nx)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversion of global longitude grids that start at 0° by correctly re-centering them around −180°.
  * Preserved expected value orientation for projected inputs.

* **Tests**
  * Added coverage for CONUS CFS GRIB conversions.
  * Updated China-domain validation to confirm converted results contain no unexpected masked values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->