### PR TITLE
✨ Add reference.ugc_state_names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to this library are documented in this file.
 - Account for FastAPI usage of `webutil.ListOrCSVType`.
 - Add `ip_throttle_secs` to `webutil.iemapp` to deal with IEM pain.
 - Add knob to `ugcs_to_text` to control total generated message size.
+- Add reference `ugc_state_names` to provide the two character prefix codes
+  used within NWS UGCs.
 - Gracefully handle `XTEUS` product without a value set.
 - Improve `iemapp` to better capture actual HTTP status_code and document
   what happens during Exception to status_code mapping.

--- a/src/pyiem/data/reference/ugc_state_names.txt
+++ b/src/pyiem/data/reference/ugc_state_names.txt
@@ -1,0 +1,74 @@
+AK Alaska
+AL Alabama
+AM Atlantic Marine
+AN Atlantic N
+AR Arkansas
+AS American Samoa
+AZ Arizona
+CA California
+CO Colorado
+CT Connecticut
+DC District of Columbia
+DE Delaware
+FL Florida
+FM Federated States of Micronesia
+GA Georgia
+GM Gulf of Mexico/America
+GU Guam
+HI Hawaii
+IA Iowa
+ID Idaho
+IL Illinois
+IN Indiana
+KS Kansas
+KY Kentucky
+LA Louisiana
+LC Lake St Clair
+LE Lake Erie
+LH Lake Huron
+LM Lake Michigan
+LO Lake Ontario
+LS Lake Superior
+MA Massachusetts
+MD Maryland
+ME Maine
+MH Marshall Islands
+MI Michigan
+MN Minnesota
+MO Missouri
+MP Northern Mariana Islands
+MS Mississippi
+MT Montana
+NC North Carolina
+ND North Dakota
+NE Nebraska
+NH New Hampshire
+NJ New Jersey
+NM New Mexico
+NV Nevada
+NY New York
+OH Ohio
+OK Oklahoma
+OR Oregon
+PA Pennsylvania
+PH Pacific Hawaii
+PK Pacific K
+PM Pacific Mexico
+PR Puerto Rico
+PS Pago Pago
+PW Pacific West
+PZ Pacific Ocean
+RI Rhode Island
+SC South Carolina
+SD South Dakota
+SL St Lawrence River
+TN Tennessee
+TX Texas
+UT Utah
+VA Virginia
+VI Virgin Islands
+VT Vermont
+WA Washington
+WI Wisconsin
+WV West Virginia
+WY Wyoming

--- a/src/pyiem/reference.py
+++ b/src/pyiem/reference.py
@@ -807,6 +807,8 @@ shef_english_units = {}
 shef_standard_units = {}
 shef_table7 = {}
 state_names = {}
+# Includes all two letter codes used by NWS UGC
+ugc_state_names = {}
 prodDefinitions = {}
 ncei_state_codes = {}
 nwsli2state = {}
@@ -826,6 +828,7 @@ class Wrapper:
         "shef_send_codes",
         "shef_table7",
         "state_names",
+        "ugc_state_names",
         "prodDefinitions",
         "ncei_state_codes",
         "nwsli2state",

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -4,6 +4,11 @@
 from pyiem import reference
 
 
+def test_ugc_state_names_in_state_names():
+    """Test that ugc_state_names is a superset of state_names."""
+    assert all(x in reference.ugc_state_names for x in reference.state_names)
+
+
 def test_states():
     """Test that we have the same number of states"""
     assert len(reference.state_names) == len(reference.state_bounds)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reference mapping for two-character NWS UGC codes covering states, territories, marine areas, lakes, and Pacific regions.
  * Added lazy access to the UGC code names through the reference data collection.

* **Documentation**
  * Documented the new UGC state-name reference in the upcoming release changelog.

* **Tests**
  * Added validation to ensure state names are represented in the UGC reference mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->