### PR TITLE
📝 Permit non-standard LSR unit of `in`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this library are documented in this file.
 - [SHEF] Tweak narrative storage to re-include the `:` delimiter.
 - Disable IEMAccess write of wind information from the DSM due to inprecision
   of reported units in MPH.
+- Permit non-standard `in` as LSR unit.
 - Raise minimum pydantic requirement to `2.11`.
 - Require `matplotlib>=3.11` due to test stability needs with changes to
   font rendering.

--- a/data/product_examples/LSR/LSRMPX.txt
+++ b/data/product_examples/LSR/LSRMPX.txt
@@ -1,0 +1,21 @@
+675 
+NWUS53 KMPX 180006
+LSRMPX
+
+Preliminary Local Storm Report
+National Weather Service Twin Cities/Chanhassen MN
+705 PM CDT Mon Aug 17 2026
+
+..TIME...   ...EVENT...      ...CITY LOCATION...     ...LAT.LON...
+..DATE...   ....MAG....      ..COUNTY LOCATION..ST.. ...SOURCE....
+            ..REMARKS..
+
+0635 PM     Hail             3 N Bertha              46.30N 95.05W
+08/17/2026  M1.00 in         Todd               MN   Trained Spotter
+
+            Piles of hail still in the yard 30 minutes
+            later.
+
+&&
+TDK
+$$

--- a/src/pyiem/nws/lsr.py
+++ b/src/pyiem/nws/lsr.py
@@ -35,7 +35,7 @@ ICE_XREF = {
 }
 
 MAG_UNITS = re.compile(
-    r"(ACRE|INCHES|INCH|MILE|MPH|KTS|U|FT|F|E|MI|M|TRACE)", re.IGNORECASE
+    r"(ACRE|INCHES|INCH|IN|MILE|MPH|KTS|U|FT|F|E|MI|M|TRACE)", re.IGNORECASE
 )
 # Products that are considered delayed reports
 DELAYED_THRESHOLD = timedelta(hours=12)

--- a/tests/nws/products/test_lsr.py
+++ b/tests/nws/products/test_lsr.py
@@ -7,6 +7,12 @@ from pyiem.reference import TRACE_VALUE
 from pyiem.util import get_test_file
 
 
+def test_260817_nwsconnect():
+    """Support a one off emitted from some new NWS software."""
+    prod = parser(get_test_file("LSR/LSRMPX.txt"))
+    assert abs(prod.lsrs[0].magnitude_f - 1.0) < 0.001
+
+
 def test_251120_lsrppg():
     """Test that we can handle a south latitude, gasp."""
     prod = parser(get_test_file("LSR/LSRPPG.txt"))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for parsing Local Storm Reports that use `IN` as a hail measurement unit.
  - Added a preliminary example report for a 1-inch hail event in Minnesota.

- **Bug Fixes**
  - Improved compatibility with reports generated by newer NWS software.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->