### PR TITLE
Correct exception scope for archive_fetch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,13 +2,13 @@ ci:
   autoupdate_schedule: quarterly
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.16.3"
+    rev: "v0.16.4"
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 'v2.28.0'
+    rev: 'v2.28.1'
     hooks:
       - id: pyproject-fmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to this library are documented in this file.
 
 - Account for `CNCL` as a cancellation string in `CWA` products.
 - Add preflight check of MOS database write for known column storage.
+- Correct exception catching scope of `util.archive_fetch`.
 - Handle `M` in CLI parsing as missing, improve log message.
 - Improve enforcement of str types into autoplot context parsing.
 - Improve warning log message for SPC PTS polygon QC.

--- a/src/pyiem/util.py
+++ b/src/pyiem/util.py
@@ -21,8 +21,8 @@ from html import escape
 # !important
 # Lazy import everything possible here, since this module is imported by
 # most everything.
-import httpx
 import numpy as np  # used too many places
+import requests
 
 # NB: careful with circular imports!
 from pyiem import database
@@ -94,7 +94,7 @@ def web2ldm(url, ldm_product_name, md5_from_name=False, pqinsert="pqinsert"):
     Returns:
       bool - success of this workflow.
     """
-    resp = httpx.get(url, timeout=60)
+    resp = requests.get(url, timeout=60)
     if resp.status_code != 200:
         return False
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as tmp:
@@ -552,9 +552,9 @@ def archive_fetch(
     # thrown into this generator at the yield and are swallowed here,
     # triggering `RuntimeError: generator didn't stop after throw()`.
     try:
-        resp = httpx.request(method.upper(), url, timeout=30)
+        resp = requests.request(method.upper(), url, timeout=30)
         resp.raise_for_status()
-    except Exception as exp:
+    except requests.exceptions.RequestException as exp:
         LOG.info("archive_fetch(%s) failed: %s", url, exp)
         yield None
         return

--- a/src/pyiem/util.py
+++ b/src/pyiem/util.py
@@ -547,19 +547,26 @@ def archive_fetch(
 
     tmp = None
     suffix = "." + os.path.basename(partialpath).split(".")[-1]
+    # NB: only wrap the actual fetch in this broad except, not the yields
+    # below, otherwise exceptions raised by the `with` block's caller get
+    # thrown into this generator at the yield and are swallowed here,
+    # triggering `RuntimeError: generator didn't stop after throw()`.
     try:
         resp = httpx.request(method.upper(), url, timeout=30)
         resp.raise_for_status()
-        if method.lower() == "head":
-            yield ""
-            return
-        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
-            tmp.write(resp.content)
-        yield tmp.name
-        return
     except Exception as exp:
         LOG.info("archive_fetch(%s) failed: %s", url, exp)
         yield None
+        return
+
+    if method.lower() == "head":
+        yield ""
+        return
+
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            tmp.write(resp.content)
+        yield tmp.name
     finally:
         if tmp is not None:
             os.unlink(tmp.name)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected error handling when retrieving archived files, ensuring failures during file use are no longer silently suppressed.
  - Archive fetch failures continue to return the expected empty result.

- **Chores**
  - Updated code quality and formatting checks to newer revisions.

- **Documentation**
  - Added an unreleased changelog entry describing the archive retrieval fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->