### PR TITLE
🐛 Account for iemapp(default_tz) for sts/ets gen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to this library are documented in this file.
 
 - Account for `CNCL` as a cancellation string in `CWA` products.
 - Add preflight check of MOS database write for known column storage.
+- Apply iemapp provided `default_tz` when sts/ets is naive (#1248).
 - Correct exception catching scope of `util.archive_fetch`.
 - Handle `M` in CLI parsing as missing, improve log message.
 - Improve enforcement of str types into autoplot context parsing.

--- a/src/pyiem/webutil.py
+++ b/src/pyiem/webutil.py
@@ -404,7 +404,7 @@ def add_to_environ(environ: dict, form: dict, **kwargs):
         # private / computed attributes that are needed
         environ["_cgimodel_schema"] = kwargs["schema"](**form)
         form = environ["_cgimodel_schema"].model_dump()
-    if "tz" not in form:
+    if "tz" not in form or form["tz"] is None:
         form["tz"] = kwargs.get("default_tz", "America/Chicago")
     # Important this is set before calling add_to_environ
     form["tz"] = TZ_TYPOS.get(form["tz"], form["tz"])

--- a/src/pyiem/webutil.py
+++ b/src/pyiem/webutil.py
@@ -412,7 +412,7 @@ def add_to_environ(environ: dict, form: dict, **kwargs):
     # Pre-flight check for a valid timezone
     try:
         ZoneInfo(form["tz"])
-    except ZoneInfoNotFoundError as exp:
+    except (IsADirectoryError, ValueError, ZoneInfoNotFoundError) as exp:
         raise IncompleteWebRequest("Invalid tz specified") from exp
 
     for key, val in form.items():
@@ -475,8 +475,6 @@ def add_to_environ(environ: dict, form: dict, **kwargs):
                     environ["_cgimodel_schema"].ets = ets
         except (TypeError, ValueError) as exp:
             raise IncompleteWebRequest("Invalid timestamp specified") from exp
-        except (IsADirectoryError, ZoneInfoNotFoundError) as exp:
-            raise IncompleteWebRequest("Invalid timezone specified") from exp
 
 
 def _handle_help(httphost: str, **kwargs):

--- a/src/pyiem/webutil.py
+++ b/src/pyiem/webutil.py
@@ -334,10 +334,10 @@ def log_request(environ: dict, multiplier: int = 1):
         conn.commit()
 
 
-def compute_ts_from_string(form, key):
+def compute_ts_from_string(form: dict, key: str) -> datetime:
     """Convert a string to a timestamp."""
     # Support various ISO8601 formats
-    tstr = form[key].replace("T", " ")
+    tstr: str = form[key].replace("T", " ")
     tz = ZoneInfo(form.get("tz", "America/Chicago"))
     if tstr.endswith("Z"):
         tz = ZoneInfo("UTC")
@@ -350,7 +350,7 @@ def compute_ts_from_string(form, key):
     return datetime.strptime(tstr, fmt).replace(tzinfo=tz)
 
 
-def compute_ts(form, suffix):
+def compute_ts(form: dict, suffix: str) -> datetime:
     """Figure out the timestamp."""
     # NB: form["tz"] should always be set by this point, but alas
     month = int(form.get(f"month{suffix}", form.get("month")))
@@ -420,6 +420,12 @@ def add_to_environ(environ: dict, form: dict, **kwargs):
             elif isinstance(val, str):
                 if _is_xss_payload(val):
                     raise BadWebRequest(f"XSS Key: {key} Value: {val}")
+            if (
+                isinstance(val, datetime)
+                and val.tzinfo is None
+                and kwargs.get("default_tz") is not None
+            ):
+                form[key] = val.replace(tzinfo=ZoneInfo(form["tz"]))
             environ[key] = form[key]
         else:
             warnings.warn(

--- a/src/pyiem/webutil.py
+++ b/src/pyiem/webutil.py
@@ -409,6 +409,12 @@ def add_to_environ(environ: dict, form: dict, **kwargs):
     # Important this is set before calling add_to_environ
     form["tz"] = TZ_TYPOS.get(form["tz"], form["tz"])
 
+    # Pre-flight check for a valid timezone
+    try:
+        ZoneInfo(form["tz"])
+    except ZoneInfoNotFoundError as exp:
+        raise IncompleteWebRequest("Invalid tz specified") from exp
+
     for key, val in form.items():
         if key not in environ:
             # check for XSS and other naughty things
@@ -426,6 +432,10 @@ def add_to_environ(environ: dict, form: dict, **kwargs):
                 and kwargs.get("default_tz") is not None
             ):
                 form[key] = val.replace(tzinfo=ZoneInfo(form["tz"]))
+                # Set this value back into the schema reference (le sigh)
+                schema = environ.get("_cgimodel_schema")
+                if schema is not None and key in type(schema).model_fields:
+                    setattr(schema, key, form[key])
             environ[key] = form[key]
         else:
             warnings.warn(
@@ -782,7 +792,9 @@ def _iemapp_handle_exception(
 
 
 def iemapp(**kwargs):
-    """Attempt to do all kinds of nice things for the user and the developer.
+    """Opinionated processing of CGI GET variables for mod_wsgi apps.
+
+    - A schema field name of `tz` is assumed to be destined to ZoneInfo usage.
 
     kwargs:
         - default_tz: The default timezone to use for timestamps, the default

--- a/tests/test_webutil_iemapp.py
+++ b/tests/test_webutil_iemapp.py
@@ -49,6 +49,52 @@ def test_ip_is_throttled_with_memcache_exception(random_ipv4: str):
         assert not ip_is_throttled({"REMOTE_ADDR": random_ipv4}, 1)
 
 
+def test_gh1248_default_tz():
+    """Test that default_tz is used for sts and ets generation."""
+
+    class Schema(CGIModel):
+        sts: Annotated[datetime, Field(description="Start Time")] = None
+        ets: Annotated[datetime, Field(description="End Time")] = None
+
+    @iemapp(help="FINDME", schema=Schema, default_tz="America/New_York")
+    def application(environ, start_response):
+        """Test."""
+        start_response("200 OK", [("Content-type", "text/plain")])
+        return (
+            "OK"
+            if (
+                environ["sts"].tzinfo is not None
+                and environ["ets"].tzinfo is not None
+                and environ["sts"].tzinfo.key == "America/New_York"
+                and environ["ets"].tzinfo.key == "America/New_York"
+            )
+            else "FAIL"
+        )
+
+    c = Client(application)
+    resp = c.get("/?sts=2022-01-01T00:00&ets=2022-01-02T00:00")
+    assert resp.status_code == 200
+    assert resp.text == "OK"
+
+
+def test_gh1248_default_tz_not_set():
+    """Test for naive sts when default_tz is not set.."""
+
+    class Schema(CGIModel):
+        sts: Annotated[datetime, Field(description="Start Time")] = None
+
+    @iemapp(help="FINDME", schema=Schema)
+    def application(environ, start_response):
+        """Test."""
+        start_response("200 OK", [("Content-type", "text/plain")])
+        return "OK" if environ["sts"].tzinfo is None else "FAIL"
+
+    c = Client(application)
+    resp = c.get("/?sts=2022-01-01T00:00")
+    assert resp.status_code == 200
+    assert resp.text == "OK"
+
+
 def test_iemapp_help_with_linereturns():
     """Test that we properly convert descriptions with newlines."""
 

--- a/tests/test_webutil_iemapp.py
+++ b/tests/test_webutil_iemapp.py
@@ -103,13 +103,13 @@ def test_gh1248_default_tz_invalid_tz_provided():
         tz: Annotated[str | None, Field(description="Timezone")] = None
 
     @iemapp(help="FINDME", schema=Schema, default_tz="America/New_York")
-    def application(environ, start_response):
+    def application(_environ, start_response):
         """Test."""
         start_response("200 OK", [("Content-type", "text/plain")])
         return "OK"
 
     c = Client(application)
-    resp = c.get("/?sts=2022-01-01T00:00&tz=Invalid/Timezone")
+    resp = c.get("/?sts=2022-01-01T00:00&tz=America/")
     assert resp.status_code == 422
 
 

--- a/tests/test_webutil_iemapp.py
+++ b/tests/test_webutil_iemapp.py
@@ -95,6 +95,24 @@ def test_gh1248_default_tz_not_set():
     assert resp.text == "OK"
 
 
+def test_gh1248_default_tz_invalid_tz_provided():
+    """Test that this situation errors 422."""
+
+    class Schema(CGIModel):
+        sts: Annotated[datetime, Field(description="Start Time")] = None
+        tz: Annotated[str | None, Field(description="Timezone")] = None
+
+    @iemapp(help="FINDME", schema=Schema, default_tz="America/New_York")
+    def application(environ, start_response):
+        """Test."""
+        start_response("200 OK", [("Content-type", "text/plain")])
+        return "OK"
+
+    c = Client(application)
+    resp = c.get("/?sts=2022-01-01T00:00&tz=Invalid/Timezone")
+    assert resp.status_code == 422
+
+
 def test_iemapp_help_with_linereturns():
     """Test that we properly convert descriptions with newlines."""
 
@@ -271,15 +289,19 @@ def test_iemapp_decorator():
 def test_typoed_tz():
     """Test that we handle when a tz gets commonly typoed."""
 
-    @iemapp()
+    class Schema(CGIModel):
+        tz: Annotated[str, Field(description="tz")]
+
+    @iemapp(schema=Schema)
     def application(environ, start_response):
         """Test."""
         start_response("200 OK", [("Content-type", "text/plain")])
-        return [b"Hello!"]
+        return environ["tz"]
 
     c = Client(application)
-    resp = c.get("/?tz=America/Chicage")
+    resp = c.get("/?tz=central")
     assert resp.status_code == 200
+    assert resp.text == "America/Chicago"
 
 
 def test_iemapp_raises_newdatabaseconnectionfailure():

--- a/tests/test_webutil_iemapp.py
+++ b/tests/test_webutil_iemapp.py
@@ -113,6 +113,27 @@ def test_gh1248_default_tz_invalid_tz_provided():
     assert resp.status_code == 422
 
 
+def test_gh1248_default_tz_invalid_tz_optional():
+    """Test that this situation errors 422."""
+
+    class Schema(CGIModel):
+        sts: Annotated[datetime, Field(description="Start Time")] = None
+        tz: Annotated[str | None, Field(description="Timezone")] = None
+
+    @iemapp(help="FINDME", schema=Schema, default_tz="America/New_York")
+    def application(environ, start_response):
+        """Test."""
+        start_response("200 OK", [("Content-type", "text/plain")])
+        return (
+            "OK" if environ["sts"].tzinfo.key == "America/New_York" else "FAIL"
+        )
+
+    c = Client(application)
+    resp = c.get("/?sts=2022-01-01T00:00")
+    assert resp.status_code == 200
+    assert resp.text == "OK"
+
+
 def test_iemapp_help_with_linereturns():
     """Test that we properly convert descriptions with newlines."""
 


### PR DESCRIPTION
closes #1248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed application of the configured default timezone to naive start and end date values.
  * Date values now retain the correct timezone information in applicable forms.
  * Invalid timezone settings are detected early and return a clear validation error.
  * Corrected timezone name normalization for submitted form values.
* **Documentation**
  * Added an entry describing the timezone handling fixes to the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->