### PR TITLE
Raise exceptions from ncopen instead of returning None

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,6 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 'v2.28.1'
+    rev: 'v2.29.3'
     hooks:
       - id: pyproject-fmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this library are documented in this file.
 - [SHEF] Tweak narrative storage to re-include the `:` delimiter.
 - Disable IEMAccess write of wind information from the DSM due to inprecision
   of reported units in MPH.
+- `util.ncopen` no longer will return None, but raise exceptions if opening
+  netcdf files raises.
 - Permit non-standard `in` as LSR unit.
 - Raise minimum pydantic requirement to `2.11`.
 - Require `matplotlib>=3.11` due to test stability needs with changes to

--- a/src/pyiem/util.py
+++ b/src/pyiem/util.py
@@ -17,10 +17,12 @@ import warnings
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from html import escape
+from pathlib import Path
 
 # !important
 # Lazy import everything possible here, since this module is imported by
 # most everything.
+import netCDF4
 import numpy as np  # used too many places
 import requests
 
@@ -244,8 +246,10 @@ def ssw(mixedobj):
         stdout.write(mixedobj)
 
 
-def ncopen(ncfn, mode="r", timeout=60, _sleep=5):
-    """Safely open netcdf files
+def ncopen(
+    ncfn: str | Path, mode: str = "r", timeout: int = 60, _sleep: int = 5
+) -> netCDF4.Dataset:
+    """Safely open netcdf files.
 
     The issue here is that we can only have the following situation for a
     given NetCDF file.
@@ -256,28 +260,36 @@ def ncopen(ncfn, mode="r", timeout=60, _sleep=5):
     lock files is problematic.
 
     Args:
-      ncfn (str): The netCDF filename
-      mode (str,optional): The netCDF4.Dataset open mode, default 'r'
-      timeout (int): The total time in seconds to attempt a read, default 60
+      ncfn: The netCDF filename
+      mode: The netCDF4.Dataset open mode, default 'r'
+      timeout: The total time in seconds to attempt a read, default 60.
+      _sleep: The time in seconds to sleep between attempts, default 5.
 
     Returns:
-      `netCDF4.Dataset` or `None`
-    """
-    import netCDF4
+      `netCDF4.Dataset`
 
-    if mode != "w" and not os.path.isfile(ncfn):
-        raise IOError(f"No such file {ncfn}")
+    Raises:
+        FileNotFoundError: When opening a non-existent file in a
+            non-create mode.
+        TimeoutError: When a transient open conflict does not clear before
+            timeout.
+    """
+    if mode != "w" and not Path(ncfn).exists():
+        raise FileNotFoundError(f"No such file {ncfn}")
     sts = datetime.now(timezone.utc)
-    nc = None
+    exp = None
     while (datetime.now(timezone.utc) - sts).total_seconds() < timeout:
         try:
             nc = netCDF4.Dataset(ncfn, mode)
-            nc.set_auto_scale(True)
-            break
-        except (OSError, IOError) as exp:
-            LOG.debug(exp)
-        time.sleep(_sleep)
-    return nc
+        except PermissionError as err:
+            exp = err
+            LOG.debug("open of %s failed", ncfn, stack_info=True)
+            time.sleep(_sleep)
+            continue
+        return nc
+    raise TimeoutError(
+        f"Failed to open {ncfn} after {timeout} seconds"
+    ) from exp
 
 
 def utc(year=None, month=1, day=1, hour=0, minute=0, second=0, microsecond=0):

--- a/src/pyiem/util.py
+++ b/src/pyiem/util.py
@@ -274,7 +274,7 @@ def ncopen(
         TimeoutError: When a transient open conflict does not clear before
             timeout.
     """
-    if mode != "w" and not Path(ncfn).exists():
+    if mode.startswith(("r", "a", "x")) and not Path(ncfn).exists():
         raise FileNotFoundError(f"No such file {ncfn}")
     sts = datetime.now(timezone.utc)
     exp = None

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from io import BytesIO
 
 import mock
+import netCDF4
 import numpy as np
 
 # third party
@@ -171,15 +172,25 @@ def test_ncopen_conflict():
         nc.close()
         nc = util.ncopen(tmp.name, "r")
         assert nc is not None
-        nc2 = util.ncopen(tmp.name, "w", timeout=0.1, _sleep=0.11)
-        assert nc2 is None
+        with pytest.raises(TimeoutError) as exp:
+            util.ncopen(tmp.name, "w", timeout=0.1, _sleep=0.11)
+        assert isinstance(exp.value.__cause__, PermissionError)
         nc.close()
 
 
 def test_ncopen(tmpdir):
     """Does ncopen at least somewhat work."""
-    with pytest.raises(IOError):
+    with pytest.raises(FileNotFoundError):
         util.ncopen(tmpdir / "bogus.nc")
+
+
+def test_ncopen_invalid_mode(tmpdir):
+    """Invalid modes should not be converted into TimeoutError."""
+    fn = tmpdir / "valid.nc"
+    with netCDF4.Dataset(fn, "w"):
+        pass
+    with pytest.raises(ValueError):
+        util.ncopen(fn, "not-a-netcdf-mode")
 
 
 def test_logger(caplog):


### PR DESCRIPTION
This QoL will help the situation of when ncopen is used in a context manager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `ncopen` now raises clear exceptions when files are missing, inaccessible, or opened with an invalid mode.
  - File-opening failures now preserve the underlying error when retries time out.

- **Documentation**
  - Updated the unreleased API changelog to document the revised `ncopen` error behavior.

- **Chores**
  - Updated the pinned pre-commit formatting tool version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->